### PR TITLE
[EI-199] [web] feat: Add card components 

### DIFF
--- a/web/app/ui/components/view/molocule/callout/index.tsx
+++ b/web/app/ui/components/view/molocule/callout/index.tsx
@@ -33,7 +33,7 @@ const Callout = React.forwardRef<HTMLDivElement, CalloutProps>(
     const Icon = icon;
     return (
       <div ref={ref} role="alert" className={cn(alertVariants({ variant }), className)} {...props}>
-        {Icon ? <Icon className="className=h-4 mr-2 w-4" /> : null}
+        {Icon ? <Icon className="mr-2 h-4 w-4" /> : null}
         <div className='"text-sm [&_p]:leading-relaxed"'>{content}</div>
       </div>
     );

--- a/web/app/ui/components/view/molocule/card/card-content.tsx
+++ b/web/app/ui/components/view/molocule/card/card-content.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import * as Collapsible from '@radix-ui/react-collapsible';
+
+type CardContentProps = {
+  children: React.ReactNode;
+};
+
+const CardContent = ({ children }: CardContentProps) => {
+  return (
+    <Collapsible.Content className=" h-96 w-full rounded-b-xl border border-black bg-white font-light">
+      <p className="p-4">{children}</p>
+    </Collapsible.Content>
+  );
+};
+
+export default CardContent;

--- a/web/app/ui/components/view/molocule/card/card-header.tsx
+++ b/web/app/ui/components/view/molocule/card/card-header.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import * as Collapsible from '@radix-ui/react-collapsible';
+import IconButton from '../../atom/icons/icon-button';
+
+type CardHeaderProps = {
+  title: string;
+  firstIcon?: React.ElementType;
+  secondIcon?: React.ElementType;
+} & React.HTMLAttributes<HTMLDivElement>;
+
+const CardHeader = ({ title, firstIcon, secondIcon, ...props }: CardHeaderProps) => {
+  return (
+    <div
+      className="flex items-center justify-between rounded-t-xl bg-black px-5 text-xl font-semibold text-white"
+      {...props}
+    >
+      {firstIcon ? <IconButton size="xl" icon={firstIcon} color="white" /> : null}
+      <div className="flex-grow text-center">{title}</div>
+      <Collapsible.Trigger asChild>
+        {secondIcon ? <IconButton size="xl" icon={secondIcon} color="white" /> : null}
+      </Collapsible.Trigger>
+    </div>
+  );
+};
+
+export default CardHeader;

--- a/web/app/ui/components/view/molocule/card/card-root.tsx
+++ b/web/app/ui/components/view/molocule/card/card-root.tsx
@@ -1,0 +1,18 @@
+import React, { useState } from 'react';
+import * as Collapsible from '@radix-ui/react-collapsible';
+import { ReactNode } from 'react';
+
+type CardRootProps = {
+  children: ReactNode;
+  defaultOpen: boolean;
+};
+
+export function CardRoot({ children, defaultOpen }: CardRootProps) {
+  const [open, setOpen] = useState(defaultOpen);
+
+  return (
+    <Collapsible.Root open={open} onOpenChange={setOpen}>
+      {children}
+    </Collapsible.Root>
+  );
+}

--- a/web/app/ui/components/view/molocule/card/card.stories.tsx
+++ b/web/app/ui/components/view/molocule/card/card.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import Card from '.';
+import { InfoCircledIcon, ChevronDownIcon } from '@radix-ui/react-icons';
+import CardHeader from './card-header';
+import CardContent from './card-content';
+
+const meta: Meta<typeof Card> = {
+  title: 'view/molecule/Card',
+  component: Card,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    defaultOpen: true,
+    children: (
+      <div className=" w-[1000px]">
+        <CardHeader title="Card Test: defaultOpen:true" firstIcon={InfoCircledIcon} secondIcon={ChevronDownIcon} />
+        <CardContent>
+          <div>첫 번째</div>
+          <div>두 번째</div>
+        </CardContent>
+      </div>
+    ),
+  },
+};
+
+export const False: Story = {
+  args: {
+    defaultOpen: false,
+    children: (
+      <div className=" w-[1000px]">
+        <CardHeader title="Card Test: False" firstIcon={InfoCircledIcon} secondIcon={ChevronDownIcon} />
+        <CardContent>
+          <div>첫 번째</div>
+          <div>두 번째</div>
+        </CardContent>
+      </div>
+    ),
+  },
+};

--- a/web/app/ui/components/view/molocule/card/index.ts
+++ b/web/app/ui/components/view/molocule/card/index.ts
@@ -1,0 +1,10 @@
+import CardHeader from './card-header';
+import { CardRoot } from './card-root';
+import CardContent from './card-content';
+
+const Card = Object.assign(CardRoot, {
+  Header: CardHeader,
+  Content: CardContent,
+});
+
+export default Card;

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -14,6 +14,7 @@
         "@headlessui/tailwindcss": "^0.2.0",
         "@heroicons/react": "^1.0.6",
         "@radix-ui/react-accordion": "^1.1.2",
+        "@radix-ui/react-collapsible": "^1.0.3",
         "@radix-ui/react-icons": "^1.3.0",
         "@radix-ui/react-slider": "^1.1.2",
         "@radix-ui/react-tabs": "^1.0.4",

--- a/web/package.json
+++ b/web/package.json
@@ -27,6 +27,7 @@
     "@headlessui/tailwindcss": "^0.2.0",
     "@heroicons/react": "^1.0.6",
     "@radix-ui/react-accordion": "^1.1.2",
+    "@radix-ui/react-collapsible": "^1.0.3",
     "@radix-ui/react-icons": "^1.3.0",
     "@radix-ui/react-slider": "^1.1.2",
     "@radix-ui/react-tabs": "^1.0.4",


### PR DESCRIPTION
✅ 작업 내용
chatGPT 활용 부분 카드 컴포넌트를 만들었습니다.
callout의 Icon부분 className오타 수정했습니다. 

🤔 고민 했던 부분
* Callout컴포넌트처럼 하나의 index에 구현해야하나 지금처럼 구조를 나누어서 진행해야하나에 대해 고민했었고, 분리해서 작업하였습니다. 이유는 다음과 같습니다. 1. 피그마를 보았을 때 아직 gpt 카드 부분의 디자인이 명확하게 나온 것 같지 않아서 디자인 확정시 바로 변경하기 용이하도록 하기위해 분리하였습니다. 2. 또한 content부분은 gpt api의 응답값을 확인하고 이를 반영할 때 더욱 용이하게 content내용을 변경하기 위해 다음처럼 분리하였습니다.
* card컴포넌트 자체는 분리할 이유가 없기 때문에 atom component에 들어가야하나에 대해 고민했습니다. 그러나 제가 이해하기로는 card컴포넌트는 title, content안에 또 다른 atom component가 들어갈 것이기에 molcule단위로 생각해서 molcule안에 구현하게 되었습니다.
 
🔊 도움이 필요한 부분
* card-content 안에 어떤 형식과 어떤 방법으로 들어올지 몰라 최대한 공백상태로 만들었습니다. 추후에 content안에 어떤식으로 내용이 들어오는지에 따라 추가 리팩토링 진행해야될 것 같은데 사전에 따로 어떤 작업을 하는 것이 좋은지 궁금합니다.
* Collapsible을 사용하는데 있어 옳은 방법이었나라는 생각을 가지고 있습니다. 카드를 접었다 피는 기능에 있어서는 사용하기에 충분히 좋다고 생각이 들지만 접는 것이 과연 필요할까에 대한 의구심이 들었습니다.
