### PR TITLE
[EI-206] [api] chore: fast api docker imager 최적화

### DIFF
--- a/api/docker-compose-api.yml
+++ b/api/docker-compose-api.yml
@@ -31,7 +31,13 @@ services:
     extra_hosts:
       - host.docker.internal:host-gateway
     environment:
-      - BASE_URL=${BASE_URL}
+      - FAST_DB_HOST=${FAST_DB_HOST}
+      - FAST_DB_PORT=${FAST_DB_PORT}
+      - FAST_POSTGRES_USER=${FAST_POSTGRES_USER}
+      - FAST_POSTGRES_PASSWORD=${FAST_POSTGRES_PASSWORD}
+      - FAST_SERVICE_KEY=${FAST_SERVICE_KEY}
+      - FASTAPI_URL=${FASTAPI_URL}
+      - FAST_BASE_URL=${FAST_BASE_URL}
 
 networks:
   api-net:

--- a/data-modeling-api/database.py
+++ b/data-modeling-api/database.py
@@ -6,10 +6,10 @@ from sqlalchemy.orm import sessionmaker
 
 load_dotenv()
 
-DB_HOST = os.getenv("DB_HOST")
-DB_PORT = os.getenv("DB_PORT")
-POSTGRES_USER = os.getenv("POSTGRES_USER")
-POSTGRES_PASSWORD = os.getenv("POSTGRES_PASSWORD")
+DB_HOST = os.getenv("FAST_DB_HOST")
+DB_PORT = os.getenv("FAST_DB_PORT")
+POSTGRES_USER = os.getenv("FAST_POSTGRES_USER")
+POSTGRES_PASSWORD = os.getenv("FAST_POSTGRES_PASSWORD")
 
 DATABASE_URL = f"postgresql://{POSTGRES_USER}:{POSTGRES_PASSWORD}@{DB_HOST}:{DB_PORT}/test"
 

--- a/data-modeling-api/dockerfile
+++ b/data-modeling-api/dockerfile
@@ -1,7 +1,15 @@
-FROM python:3.9
+FROM python:3.9-slim AS builder
 
 WORKDIR /code/data-modeling-api/
 
 COPY ./ /code/data-modeling-api
 
-RUN pip install --no-cache-dir --upgrade -r /code/data-modeling-api/requirements.txt
+RUN pip install --no-cache-dir -r /code/data-modeling-api/requirements.txt
+
+FROM python:3.9-slim AS production
+
+WORKDIR /code/data-modeling-api/
+
+COPY --from=builder /usr/local/lib/python3.9/site-packages/ /usr/local/lib/python3.9/site-packages/
+COPY --from=builder /usr/local/bin/ /usr/local/bin/
+COPY --from=builder /code/data-modeling-api /code/data-modeling-api

--- a/data-modeling-api/dockerfile
+++ b/data-modeling-api/dockerfile
@@ -13,3 +13,5 @@ WORKDIR /code/data-modeling-api/
 COPY --from=builder /usr/local/lib/python3.9/site-packages/ /usr/local/lib/python3.9/site-packages/
 COPY --from=builder /usr/local/bin/ /usr/local/bin/
 COPY --from=builder /code/data-modeling-api /code/data-modeling-api
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8001", "--reload"]

--- a/data-modeling-api/service.py
+++ b/data-modeling-api/service.py
@@ -13,7 +13,7 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-BASE_URL = os.getenv("BASE_URL")
+BASE_URL = os.getenv("FAST_BASE_URL")
 
 def predict(targetIndicatorId:str, sourceIndicatorIds: list[str], weights: list[int], db: Session) -> ForecastIndicatorDto:
   # 데이터베이스로부터 Indicator 정보 가져오기


### PR DESCRIPTION
## ✅ 작업 내용
- 도커 이미지를 최적화했습니다.
- base 이미지를 바꿔서 용량을 줄였습니다.
- builder단계와 production 단계를 나눈 멀티 스테이지 빌드를 적용했습니다.

## 🤔 고민 했던 부분
- 환경변수를 넣을 때 기존에 dockerfile과 같은 위치에 있는 .env파일을 통째로 복사하는 방식을 택했습니다.
- 첫번째 이유는 fast api에서 사용하는 db 호스트와 nest에서 사용하는 db호스트가 다릅니다. db와 fast api는 컨테이너끼리 통신이라 localhost대신 host.docker.internal을 사용해야합니다. 두번째 이유는 docker-compose-api-up실행할 때 파이썬 파일들이 생기는 폴더(data-modeling-api)의 상위 폴더(api)에 nest에서 사용되는 env파일이 위치하기 때문에 별 다른 문제가 없다면 .env파일은 data-modelig-api에서 보관하는게 좋을 것 같다는 생각을 했습니다.

## 🔊 도움이 필요한 부분
- 위 고민에대해서 의견 주시면 감사하겠습니다 🥹