### PR TITLE
[EI-248] [api] refactor: fast api DB세션 관리 추가, 예측값 불러올 때와 granger 검증과 예측 분리

### DIFF
--- a/apps/data-modeling-api/database.py
+++ b/apps/data-modeling-api/database.py
@@ -14,14 +14,12 @@ POSTGRES_PASSWORD = os.getenv("FAST_POSTGRES_PASSWORD")
 DATABASE_URL = f"postgresql://{POSTGRES_USER}:{POSTGRES_PASSWORD}@{DB_HOST}:{DB_PORT}/test"
 
 engine = create_engine(DATABASE_URL)
-
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
-
 Base = declarative_base()
 
 def get_db():
     db = SessionLocal()
     try:
-        return db
+        yield db
     finally:
         db.close()

--- a/apps/data-modeling-api/main.py
+++ b/apps/data-modeling-api/main.py
@@ -1,7 +1,8 @@
-from fastapi import HTTPException, Query
+from fastapi import Depends, Query
 from fastapi import FastAPI
 from service import predict, sourceIndicatorsVerification, predictWithoutTargetIndicator
 from database import engine, Base, get_db
+from sqlalchemy.orm import Session
 
 Base.metadata.create_all(bind=engine) 
 
@@ -11,18 +12,20 @@ def hello() :
 	return "Hello, Fingoo!"
 
 @app.get("/api/var-api/custom-forecast-indicator/")
-def loadPredictedIndicator(
+def loadIndicatorValue(
     targetIndicatorId: str = Query(...),
     targetIndicatorType: str = Query(...),
     sourceIndicatorId: list[str] = Query(default = None),
     sourceIndicatorType: list[str] = Query(default = None),
     weight: list[int] = Query(default = None),
+    validIndicatorId: list[str] = Query(default = None),
+    db: Session = Depends(get_db)
     ):
 	
     if not sourceIndicatorId and not weight:
-        prediction = predictWithoutTargetIndicator(targetIndicatorId, targetIndicatorType, get_db())
+        prediction = predictWithoutTargetIndicator(targetIndicatorId, targetIndicatorType, db)
     else:
-        prediction = predict(targetIndicatorId, targetIndicatorType, sourceIndicatorId, sourceIndicatorType, weight, get_db())
+        prediction = predict(targetIndicatorId, targetIndicatorType, sourceIndicatorId, sourceIndicatorType, weight, validIndicatorId, db)
 
     return prediction
 
@@ -33,6 +36,7 @@ def loadSourceIndicatorsVerification(
     sourceIndicatorId: list[str] = Query(default = None),
     sourceIndicatorType: list[str] = Query(default = None),
     weight: list[int] = Query(default = None),
+    db: Session = Depends(get_db)
     ):
-	verificaion = sourceIndicatorsVerification(targetIndicatorId, targetIndicatorType, sourceIndicatorId, sourceIndicatorType, weight, get_db())
+	verificaion = sourceIndicatorsVerification(targetIndicatorId, targetIndicatorType, sourceIndicatorId, sourceIndicatorType, weight, db)
 	return verificaion


### PR DESCRIPTION
## ✅ 작업 내용
- fast api 서버 안정화 작업을 진행했습니다.
- 1. fast api 서버내에서 예측을 진행할 경우, granger검정을 1차적으로 거친 후 var 예측을 진행했습니다.
- 하지만 성능상 좋지 못한 설계인 것 같아, 예측값을 불러올 때 fast api에게 사전에 이미 검증된 지표를 보내 사전에 검증된 유효한 지표들로만 var예측을 진행하도록 진행했습니다. 
- 2. DB세션관리
- 서버에서 timeout error를 뜨는 로그를 살펴보고 찾아보니 SQLAlchemy에서 세션반환이 잘 이루어지지 않고 있음을 확인했습니다.
- https://spoqa.github.io/2018/01/17/connection-pool-of-sqlalchemy.html
- 세션관리를 위해 현재 동작하는 db세션이 동작이 끝나면 세션을 종료하는 함수를 만들어주고, 사용되는 코드에 fast api 에서 의존성 주입하는 방식으로 구현했습니다. https://spoqa.github.io/2018/01/17/connection-pool-of-sqlalchemy.html