### PR TITLE
Ei 248

### DIFF
--- a/apps/api/src/numerical-guidance/infrastructure/adapter/persistence/custom-forecast-indicator/custom-forecast-indicator.persistent.adapter.ts
+++ b/apps/api/src/numerical-guidance/infrastructure/adapter/persistence/custom-forecast-indicator/custom-forecast-indicator.persistent.adapter.ts
@@ -341,7 +341,6 @@ export class CustomForecastIndicatorPersistentAdapter
     if (entity == null) throw new NotFoundException();
   }
 
-  // ToDo: 리스트가 비어있을 경우 Arima만 가도록 ...
   private getValidIndicators(customForecastIndicator: CustomForecastIndicator): SourceIndicatorInformation[] {
     const allIndicatorsInformation = customForecastIndicator.sourceIndicatorsInformation;
     allIndicatorsInformation.push({

--- a/apps/api/src/numerical-guidance/infrastructure/adapter/persistence/custom-forecast-indicator/custom-forecast-indicator.persistent.adapter.ts
+++ b/apps/api/src/numerical-guidance/infrastructure/adapter/persistence/custom-forecast-indicator/custom-forecast-indicator.persistent.adapter.ts
@@ -220,11 +220,11 @@ export class CustomForecastIndicatorPersistentAdapter
       customForecastIndicatorEntity.sourceIndicators = customForecastIndicator.sourceIndicators;
 
       if (customForecastIndicatorEntity.sourceIndicatorsInformation.length == 0) {
-        const grangerGroup = [];
-        const cointJohansenVerification = [];
+        const emptyGrangerGroup = [];
+        const emptyCointJohansenVerification = [];
 
-        customForecastIndicatorEntity.grangerVerification = grangerGroup;
-        customForecastIndicatorEntity.cointJohansenVerification = cointJohansenVerification;
+        customForecastIndicatorEntity.grangerVerification = emptyGrangerGroup;
+        customForecastIndicatorEntity.cointJohansenVerification = emptyCointJohansenVerification;
       } else {
         const url: string =
           process.env.FASTAPI_URL +
@@ -341,6 +341,7 @@ export class CustomForecastIndicatorPersistentAdapter
     if (entity == null) throw new NotFoundException();
   }
 
+  // ToDo: 리스트가 비어있을 경우 Arima만 가도록 ...
   private getValidIndicators(customForecastIndicator: CustomForecastIndicator): SourceIndicatorInformation[] {
     const allIndicatorsInformation = customForecastIndicator.sourceIndicatorsInformation;
     allIndicatorsInformation.push({
@@ -348,10 +349,16 @@ export class CustomForecastIndicatorPersistentAdapter
       indicatorType: customForecastIndicator.targetIndicator.indicatorType,
       weight: null,
     });
-    const validIndicators = allIndicatorsInformation.filter(
-      (_SourceIndicatorInformation, index) =>
-        customForecastIndicator.grangerVerification[index].verification === 'True',
-    );
-    return validIndicators;
+
+    switch (allIndicatorsInformation.length) {
+      case 1:
+        return [];
+      default:
+        const validIndicators = allIndicatorsInformation.filter(
+          (_SourceIndicatorInformation, index) =>
+            customForecastIndicator.grangerVerification[index].verification === 'True',
+        );
+        return validIndicators;
+    }
   }
 }

--- a/apps/data-modeling-api/forecastModule/forecast.py
+++ b/apps/data-modeling-api/forecastModule/forecast.py
@@ -3,9 +3,10 @@ from statsmodels.tsa.arima.model import ARIMA
 from verificationModule import verification
 import pandas as pd
 import numpy as np
+import pmdarima as pm
 
 def runVar(df: pd.DataFrame, group: list[str], period: int) -> pd.DataFrame:
-  df = df.fillna(method='backfill')
+  df = df.bfill()
 
   dfVar = df[group]
   for i in group:
@@ -26,7 +27,7 @@ def runVar(df: pd.DataFrame, group: list[str], period: int) -> pd.DataFrame:
   return dfVarDnorm
 
 def runArima(df: pd.DataFrame, target: str, period: int) -> pd.DataFrame:
-  df = df.fillna(method='backfill')
+  df = df.bfill()
   
   order = optimizationArima(df, target)
   p = int(order[0])
@@ -42,31 +43,12 @@ def runArima(df: pd.DataFrame, target: str, period: int) -> pd.DataFrame:
   return forecast_df
 
 def optimizationArima(df: pd.DataFrame, target: str) -> str:
-  df = df.fillna(method='backfill')
+  df = df.bfill()
+    
+  auto_model = pm.auto_arima(df[target], seasonal=False, trace=True,
+    error_action='ignore', suppress_warnings=True,
+    stepwise=True, n_jobs=-1)
 
-  order = [3, 3, 3]
-  orderList = []
-  aicList = []
-  bicList = []
+  best_order = auto_model.order
 
-  for p in range(0, order[0]):
-    for q in range(0, order[1]):
-      for d in range(0, order[2]):
-        model = ARIMA(df[target], order=(p, q, d))
-        try:
-          fitted_model = model.fit()
-          Corder = f'{p}{d}{q}'
-          aic = fitted_model.aic
-          bic = fitted_model.bic
-          orderList.append(Corder)
-          aicList.append(aic)
-          bicList.append(bic)
-        except:
-          pass
-  resultDf = pd.DataFrame(list(zip(orderList, aicList)), columns=['order','AIC'])
-  resultDf.sort_values('AIC', inplace= True)
-
-  minAicRow = resultDf.loc[resultDf['AIC'].idxmin()]
-  minOrder = minAicRow['order']
-
-  return minOrder
+  return best_order

--- a/apps/data-modeling-api/main.py
+++ b/apps/data-modeling-api/main.py
@@ -1,4 +1,4 @@
-from fastapi import Depends, Query
+from fastapi import Depends, HTTPException, Query
 from fastapi import FastAPI
 from service import predict, sourceIndicatorsVerification, predictWithoutTargetIndicator
 from database import engine, Base, get_db
@@ -21,13 +21,15 @@ def loadIndicatorValue(
     validIndicatorId: list[str] = Query(default = None),
     db: Session = Depends(get_db)
     ):
-	
-    if not sourceIndicatorId and not weight:
-        prediction = predictWithoutTargetIndicator(targetIndicatorId, targetIndicatorType, db)
-    else:
-        prediction = predict(targetIndicatorId, targetIndicatorType, sourceIndicatorId, sourceIndicatorType, weight, validIndicatorId, db)
+      try:
+        if not sourceIndicatorId and not weight:
+          prediction = predictWithoutTargetIndicator(targetIndicatorId, targetIndicatorType, db)
+        else:
+          prediction = predict(targetIndicatorId, targetIndicatorType, sourceIndicatorId, sourceIndicatorType, weight, validIndicatorId, db)
 
-    return prediction
+        return prediction
+      except Exception as error:
+          raise HTTPException(status_code=500, detail=f"{str(error)}")
 
 @app.get("/api/var-api/source-indicators-verification/")
 def loadSourceIndicatorsVerification(
@@ -38,5 +40,8 @@ def loadSourceIndicatorsVerification(
     weight: list[int] = Query(default = None),
     db: Session = Depends(get_db)
     ):
-	verificaion = sourceIndicatorsVerification(targetIndicatorId, targetIndicatorType, sourceIndicatorId, sourceIndicatorType, weight, db)
-	return verificaion
+      try:
+        verificaion = sourceIndicatorsVerification(targetIndicatorId, targetIndicatorType, sourceIndicatorId, sourceIndicatorType, weight, db)
+        return verificaion
+      except Exception as error:
+        raise HTTPException(status_code=500, detail=f"{str(error)}")

--- a/apps/data-modeling-api/requirements.txt
+++ b/apps/data-modeling-api/requirements.txt
@@ -9,3 +9,4 @@ SQLAlchemy==2.0.28
 statsmodels==0.14.1
 python-dotenv==1.0.0
 urllib3==2.2.1
+pmdarima==2.0.4

--- a/apps/data-modeling-api/service.py
+++ b/apps/data-modeling-api/service.py
@@ -81,7 +81,6 @@ def predict(targetIndicatorId:str, targetIndicatorType: str, sourceIndicatorIds:
     if len(validIndicatorId) >= 2:
       if targetIndicatorId in validIndicatorId:
         print('Var')
-        # df_var을 유효성 검증으로 바꿔야함
         customForecastIndicator = forecast.runVar(df_var, validIndicatorId, int(len(df_var)/2))
         for id in validIndicatorId:
           if id == targetIndicatorId:


### PR DESCRIPTION
## ✅ 작업 내용
- 1. 재료지표가 아예 비어있을 경우, 예측값을 불러오지 못하는 오류를 수정했습니다.
- - 기존에는 예측지표에서 Granger검정을 바탕으로 유효한 지표 id를 골라내는 로직에서 재료지표가 아예없을 경우에 대한 처리가 부실했습니다.
- 2. 서버가 죽은 이유 중 하나가 arima의 성능이라고 생각했고, p,q,d를 최적화 하는 과정에서 시간이 오래 걸린다는 사실을 확인해 autoArima라는 모델로 바꿔주었습니다.
- 기존에는 최적의 pqd조합을 찾기위해 일일히 arima모델을 만들어가면 AIC값을 확인했습니다. 이 과정에서 시간이 오래걸려, pmdarima에서 제공하는 autoArima를 도입해 빠르게 최적의 p,q,d값을 제공해주어 성능을 개선할 수 있습니다.
- https://pypi.org/project/pmdarima/