### PR TITLE
Ei 259 버그 수정

### DIFF
--- a/apps/api/src/numerical-guidance/infrastructure/adapter/twelve/indicator.twelve.adapter.ts
+++ b/apps/api/src/numerical-guidance/infrastructure/adapter/twelve/indicator.twelve.adapter.ts
@@ -71,15 +71,12 @@ export class IndicatorTwelveAdapter implements SearchTwelveIndicatorPort, LoadLi
     rowStartDate: string,
     rowEndDate: string,
   ): Promise<LiveIndicatorDtoType> {
-    console.log('loadLiveIndicator', indicatorDto, interval, rowStartDate, rowEndDate);
     const responseData = await this.twelveApiUtil.getTimeSeries(
       indicatorDto.symbol,
       interval,
       rowStartDate,
       rowEndDate,
     );
-
-    console.log(responseData);
 
     const values: IndicatorValue[] = this.convertRowDataToIndicatorValue(responseData);
     return await this.generateIndicatorDto(interval, indicatorDto, responseData, values);

--- a/apps/api/src/numerical-guidance/infrastructure/adapter/twelve/util/twelve-api.manager.ts
+++ b/apps/api/src/numerical-guidance/infrastructure/adapter/twelve/util/twelve-api.manager.ts
@@ -34,6 +34,7 @@ export class TwelveApiManager {
       const requestUrl: string = `${BASE_URL}/time_series/?symbol=${symbol}&interval=${twelveInterval}&start_date=${startDate}&end_date=${endDate}&apikey=${process.env.TWELVE_KEY}`;
       const response = await this.api.axiosRef.get(requestUrl);
       const resultResponse = this.checkTwelveException(response.data);
+      console.log(resultResponse);
       return resultResponse;
     } catch (error) {
       if (error instanceof NotFoundException) {
@@ -58,12 +59,14 @@ export class TwelveApiManager {
       return '1week';
     }
   }
-  private checkTwelveException(responseData: any): unknown {
+  private checkTwelveException(responseData: any): { values: [] } {
     if (responseData.code == 400) {
-      return { values: [] };
+      const result: { values: [] } = { values: [] };
+      return result;
     }
     if (responseData.code == 404) {
       throw new NotFoundException();
     }
+    return responseData;
   }
 }

--- a/apps/api/src/numerical-guidance/infrastructure/adapter/twelve/util/twelve-api.manager.ts
+++ b/apps/api/src/numerical-guidance/infrastructure/adapter/twelve/util/twelve-api.manager.ts
@@ -10,7 +10,14 @@ export class TwelveApiManager {
   constructor(private readonly api: HttpService) {}
 
   async getReferenceData(type: IndicatorType, country: string) {
-    const requestUrl: string = `${BASE_URL}/${type}?country=${country}`;
+    // TODO: 베타 이후 삭제 예정
+    let requestUrl: string;
+    if (type == 'funds') {
+      requestUrl = `${BASE_URL}/${type}?country=${country}&exchange=NASDAQ`;
+      const response = await this.api.axiosRef.get(requestUrl);
+      return response.data;
+    }
+    requestUrl = `${BASE_URL}/${type}?country=${country}`;
     const response = await this.api.axiosRef.get(requestUrl);
     return response.data;
   }


### PR DESCRIPTION
## ✅ 작업 내용
- 베타테스트 시에는 funds가 NASDAQ만 사용할 수 있기에 해당 데이터만 저장하도록 변경했습니다.
- twelve api에서 startdate가 1901년 01월 01일 이전의 날은 사용할 수 없기 때문에 예외처리를 하고있었지만, 해당 데이터가 없는 것이므로 서비스에 맞게 빈 배열을 반환하도록 변경했습니다.