### PR TITLE
Ei 258

### DIFF
--- a/apps/api/src/numerical-guidance/infrastructure/adapter/persistence/custom-forecast-indicator/custom-forecast-indicator.persistent.adapter.ts
+++ b/apps/api/src/numerical-guidance/infrastructure/adapter/persistence/custom-forecast-indicator/custom-forecast-indicator.persistent.adapter.ts
@@ -37,7 +37,7 @@ export class CustomForecastIndicatorPersistentAdapter
     @InjectRepository(CustomForecastIndicatorEntity)
     private readonly customForecastIndicatorRepository: Repository<CustomForecastIndicatorEntity>,
     @InjectRepository(IndicatorBoardMetadataEntity)
-    private readonly indicatorBoardMetaDataRepository: Repository<IndicatorBoardMetadataEntity>,
+    private readonly indicatorBoardMetadataRepository: Repository<IndicatorBoardMetadataEntity>,
     private readonly authService: AuthService,
     private readonly api: HttpService,
   ) {}
@@ -315,22 +315,22 @@ export class CustomForecastIndicatorPersistentAdapter
       this.nullCheckForEntity(customForecastIndicatorEntity);
       await this.customForecastIndicatorRepository.remove(customForecastIndicatorEntity);
 
-      const indicatorBoardMetaDataEntities: IndicatorBoardMetadataEntity[] = await this.indicatorBoardMetaDataRepository
-        .createQueryBuilder('indicatorBordMetaData')
-        .where('indicatorBordMetaData.customForecastIndicatorIds @> :id', { id: `"${customForecastIndicatorId}"` })
+      const indicatorBoardMetadataEntities: IndicatorBoardMetadataEntity[] = await this.indicatorBoardMetadataRepository
+        .createQueryBuilder('indicatorBordMetadata')
+        .where('indicatorBordMetadata.customForecastIndicatorIds @> :id', { id: `"${customForecastIndicatorId}"` })
         .getMany();
-      for (const indicatorBoardMetadataEntity of indicatorBoardMetaDataEntities) {
+
+      for (const indicatorBoardMetadataEntity of indicatorBoardMetadataEntities) {
         indicatorBoardMetadataEntity.customForecastIndicatorIds =
           indicatorBoardMetadataEntity.customForecastIndicatorIds.filter((id) => id !== customForecastIndicatorId);
 
         for (const section in indicatorBoardMetadataEntity.sections) {
-          const sectionsStr: string = `${indicatorBoardMetadataEntity.sections[section]}`;
-          let sectionsList = this.stringToList(sectionsStr);
-          sectionsList = sectionsList.filter((id) => id !== customForecastIndicatorId);
-          indicatorBoardMetadataEntity.sections[section] = sectionsList;
+          let sectionsArray = this.convertRecordValueToArray(indicatorBoardMetadataEntity.sections[section]);
+          sectionsArray = sectionsArray.filter((id) => id !== customForecastIndicatorId);
+          indicatorBoardMetadataEntity.sections[section] = sectionsArray;
         }
       }
-      await this.indicatorBoardMetaDataRepository.save(indicatorBoardMetaDataEntities);
+      await this.indicatorBoardMetadataRepository.save(indicatorBoardMetadataEntities);
     } catch (error) {
       if (error instanceof NotFoundException) {
         throw new NotFoundException({
@@ -361,7 +361,8 @@ export class CustomForecastIndicatorPersistentAdapter
     if (entity == null) throw new NotFoundException();
   }
 
-  private stringToList(str: string): string[] {
+  private convertRecordValueToArray(stringList: string[]): string[] {
+    const str: string = `${stringList}`;
     const list: string[] = str.split(',');
     return list;
   }

--- a/apps/api/src/numerical-guidance/infrastructure/adapter/persistence/custom-forecast-indicator/custom-forecast-indicator.persistent.adapter.ts
+++ b/apps/api/src/numerical-guidance/infrastructure/adapter/persistence/custom-forecast-indicator/custom-forecast-indicator.persistent.adapter.ts
@@ -325,9 +325,9 @@ export class CustomForecastIndicatorPersistentAdapter
           indicatorBoardMetadataEntity.customForecastIndicatorIds.filter((id) => id !== customForecastIndicatorId);
 
         for (const section in indicatorBoardMetadataEntity.sections) {
-          let sectionsArray = this.convertRecordValueToArray(indicatorBoardMetadataEntity.sections[section]);
-          sectionsArray = sectionsArray.filter((id) => id !== customForecastIndicatorId);
-          indicatorBoardMetadataEntity.sections[section] = sectionsArray;
+          const sectionsArray = this.convertRecordValueToArray(indicatorBoardMetadataEntity.sections[section]);
+          const updatedDectionsArray = sectionsArray.filter((id) => id !== customForecastIndicatorId);
+          indicatorBoardMetadataEntity.sections[section] = updatedDectionsArray;
         }
       }
       await this.indicatorBoardMetadataRepository.save(indicatorBoardMetadataEntities);

--- a/apps/api/src/numerical-guidance/test/integration-test/adapter/persistence/custom-forecast-indicator.persistent.adapter.spec.ts
+++ b/apps/api/src/numerical-guidance/test/integration-test/adapter/persistence/custom-forecast-indicator.persistent.adapter.spec.ts
@@ -12,6 +12,7 @@ import { CustomForecastIndicatorEntity } from 'src/numerical-guidance/infrastruc
 import { DataSource } from 'typeorm';
 import { IndicatorEntity } from 'src/numerical-guidance/infrastructure/adapter/persistence/indicator/entity/indicator.entity';
 import { SupabaseService } from '../../../../../auth/supabase/supabase.service';
+import { IndicatorBoardMetadataEntity } from 'src/numerical-guidance/infrastructure/adapter/persistence/indicator-board-metadata/entity/indicator-board-metadata.entity';
 
 jest.mock('typeorm-transactional', () => ({
   Transactional: () => () => ({}),
@@ -127,7 +128,12 @@ describe('CustomForecastIndicatorPersistentAdapter', () => {
             maxRedirects: 5,
           }),
         }),
-        TypeOrmModule.forFeature([CustomForecastIndicatorEntity, MemberEntity, IndicatorEntity]),
+        TypeOrmModule.forFeature([
+          CustomForecastIndicatorEntity,
+          MemberEntity,
+          IndicatorEntity,
+          IndicatorBoardMetadataEntity,
+        ]),
         TypeOrmModule.forRootAsync({
           imports: [ConfigModule],
           inject: [ConfigService],
@@ -140,7 +146,7 @@ describe('CustomForecastIndicatorPersistentAdapter', () => {
             username: environment.getUsername(),
             password: environment.getPassword(),
             database: environment.getDatabase(),
-            entities: [CustomForecastIndicatorEntity, MemberEntity, IndicatorEntity],
+            entities: [CustomForecastIndicatorEntity, MemberEntity, IndicatorEntity, IndicatorBoardMetadataEntity],
             synchronize: true,
           }),
         }),

--- a/apps/api/src/numerical-guidance/test/integration-test/adapter/persistence/custom-forecast-indicator.persistent.adapter.spec.ts
+++ b/apps/api/src/numerical-guidance/test/integration-test/adapter/persistence/custom-forecast-indicator.persistent.adapter.spec.ts
@@ -316,7 +316,6 @@ describe('CustomForecastIndicatorPersistentAdapter', () => {
     );
 
     // then
-    console.log(indicatorBoardMetadata.customForecastIndicatorIds);
     expect(indicatorBoardMetadata.customForecastIndicatorIds.length).toEqual(0);
     expect(indicatorBoardMetadata.sections['section1'].length).toEqual(0);
   });


### PR DESCRIPTION
## ✅ 작업 내용
- 예측지표 삭제 시, 지표보드 메타데이터에는 업데이트 되지 않는 버그를 수정했습니다.

## 🤔 고민 했던 부분
-  예측지표 id가 지표보드 메타데이터와 직접 연관을 짓고있지 않아, 어떻게 처리할 지 고민했습니다.
-  쿼리빌더를 이용해 삭제하고자 하는 예측지표를 가진 메타데이터를 찾고, 해당 메타데이들에서 예측지표를 삭제한 상태로 업데이트 했습니다.
- section은 record로 구현되어있어서, DB에 문자열로 저장되는 이슈가 있어서 해당 데이터를 다시 문자열 리스트로 바꿔 준 후 업데이트하는 방식으로 구현했습니다.