### PR TITLE
[Ei 999 intern] Fix Typo and Refactor onClick Handler Type

### DIFF
--- a/apps/web/app/business/hooks/numerical-guidance/indicator-board-metedata/use-indicator-board-metadata-list-view-model.hook.ts
+++ b/apps/web/app/business/hooks/numerical-guidance/indicator-board-metedata/use-indicator-board-metadata-list-view-model.hook.ts
@@ -6,7 +6,7 @@ import {
 } from '../../../../store/querys/numerical-guidance/indicator-board-metadata.query';
 import { useFetchIndicatorBoardMetadataList } from '../../../../store/querys/numerical-guidance/indicator-board-metadata.query';
 import { useEffect, useMemo } from 'react';
-import { convertIndcatorBoardMetadataList } from '@/app/business/services/numerical-guidance/view-model/indicator-board-metadata/indicator-board-metadata-list-view-model.service';
+import { convertIndicatorBoardMetadataList } from '@/app/business/services/numerical-guidance/view-model/indicator-board-metadata/indicator-board-metadata-list-view-model.service';
 import {
   IndicatorInMetadataUnitTypes,
   useIndicatorBoardMetadataStore,
@@ -31,7 +31,7 @@ export const useIndicatorBoardMetadataList = () => {
   const convertedIndicatorBoardMetadataList = useMemo(() => {
     if (!indicatorBoardMetadataList) return undefined;
 
-    return convertIndcatorBoardMetadataList(indicatorBoardMetadataList);
+    return convertIndicatorBoardMetadataList(indicatorBoardMetadataList);
   }, [indicatorBoardMetadataList]);
 
   useEffect(() => {

--- a/apps/web/app/business/hooks/numerical-guidance/indicator-board-metedata/use-indicator-board-metadata-view-model.hook.ts
+++ b/apps/web/app/business/hooks/numerical-guidance/indicator-board-metedata/use-indicator-board-metadata-view-model.hook.ts
@@ -6,7 +6,7 @@ import {
   useUpdateIndicatorIdsWithsectionIds,
   useUploadIndicatorBoardMetadataImage,
 } from '@/app/store/querys/numerical-guidance/indicator-board-metadata.query';
-import { convertIndcatorBoardMetadataList } from '@/app/business/services/numerical-guidance/view-model/indicator-board-metadata/indicator-board-metadata-list-view-model.service';
+import { convertIndicatorBoardMetadataList } from '@/app/business/services/numerical-guidance/view-model/indicator-board-metadata/indicator-board-metadata-list-view-model.service';
 import { useMemo } from 'react';
 import { useIndicatorBoardMetadataStore } from '@/app/store/stores/numerical-guidance/indicator-board-metadata.store';
 
@@ -26,7 +26,7 @@ export const useIndicatorBoardMetadataViewModel = (metadataId: string | undefine
   const convertedIndicatorBoardMetadataList = useMemo(() => {
     if (!indicatorBoardMetadataList) return undefined;
 
-    return convertIndcatorBoardMetadataList(indicatorBoardMetadataList);
+    return convertIndicatorBoardMetadataList(indicatorBoardMetadataList);
   }, [indicatorBoardMetadataList]);
 
   const indicatorBoardMetadata = metadataId

--- a/apps/web/app/business/hooks/numerical-guidance/indicator-board-metedata/use-selected-indicator-board-metadata-view-model.hook.ts
+++ b/apps/web/app/business/hooks/numerical-guidance/indicator-board-metedata/use-selected-indicator-board-metadata-view-model.hook.ts
@@ -9,7 +9,7 @@ import {
   useFetchIndicatorBoardMetadataList,
 } from '../../../../store/querys/numerical-guidance/indicator-board-metadata.query';
 import { useWorkspaceStore } from '../../../../store/stores/numerical-guidance/workspace.store';
-import { convertIndcatorBoardMetadataList } from '@/app/business/services/numerical-guidance/view-model/indicator-board-metadata/indicator-board-metadata-list-view-model.service';
+import { convertIndicatorBoardMetadataList } from '@/app/business/services/numerical-guidance/view-model/indicator-board-metadata/indicator-board-metadata-list-view-model.service';
 import { useWorkspace } from '../../use-workspace.hook';
 
 export const useSelectedIndicatorBoardMetadata = () => {
@@ -27,7 +27,7 @@ export const useSelectedIndicatorBoardMetadata = () => {
   const convertedIndicatorBoardMetadataList = useMemo(() => {
     if (!indicatorBoardMetadataList) return undefined;
 
-    return convertIndcatorBoardMetadataList(indicatorBoardMetadataList);
+    return convertIndicatorBoardMetadataList(indicatorBoardMetadataList);
   }, [indicatorBoardMetadataList]);
 
   const selectedMetadata = useMemo(() => {

--- a/apps/web/app/business/services/numerical-guidance/view-model/indicator-board-metadata/indicator-board-metadata-list-view-model.service.ts
+++ b/apps/web/app/business/services/numerical-guidance/view-model/indicator-board-metadata/indicator-board-metadata-list-view-model.service.ts
@@ -26,7 +26,7 @@ export class IndicatorBoardMetadataList extends Array<IndicatorBoardMetadata> {
   }
 
   iterate(callback: (metadata: IndicatorBoardMetadata) => IndicatorBoardMetadata): IndicatorBoardMetadataList {
-    return convertIndcatorBoardMetadataList(this.map(callback));
+    return convertIndicatorBoardMetadataList(this.map(callback));
   }
 
   findIndicatorBoardMetadataById(metadataId: string) {
@@ -34,7 +34,7 @@ export class IndicatorBoardMetadataList extends Array<IndicatorBoardMetadata> {
   }
 
   deleteIndicatorBoardMetadata(metadataId: string) {
-    return convertIndcatorBoardMetadataList(this.filter((metadata) => metadata.id !== metadataId));
+    return convertIndicatorBoardMetadataList(this.filter((metadata) => metadata.id !== metadataId));
   }
 
   addIndicatorToMetadataById(metadataId: string | undefined, indicatorInfo: IndicatorInfoResponse) {
@@ -117,6 +117,6 @@ export class IndicatorBoardMetadataList extends Array<IndicatorBoardMetadata> {
     });
   }
 }
-export const convertIndcatorBoardMetadataList = (response: IndicatorBoardMetadataResponse[]) => {
+export const convertIndicatorBoardMetadataList = (response: IndicatorBoardMetadataResponse[]) => {
   return new IndicatorBoardMetadataList(response);
 };

--- a/apps/web/app/logging/component/log-click.tsx
+++ b/apps/web/app/logging/component/log-click.tsx
@@ -17,11 +17,11 @@ export function LogClick({ children, event, properties }: React.PropsWithChildre
   }
 
   return React.cloneElement(child as React.ReactElement, {
-    onClick: (...args: any[]) => {
+    onClick: (e: React.MouseEvent<HTMLElement>) => {
       logger.track(event, properties);
 
       if (child.props && typeof child.props['onClick'] === 'function') {
-        return child.props['onClick'](...args);
+        return child.props['onClick'](e);
       }
     },
   });


### PR DESCRIPTION
## ✅ 작업 내용
- 오타 수정: `convertIndcatorBoardMetadataList`를 `convertIndicatorBoardMetadataList`로 변경
- `onClick` 핸들러의 타입을 명시적으로 `React.MouseEvent<HTMLElement>`로 지정

## 🤔 고민 했던 부분
- `onClick` 핸들러의 타입을 지정할 때 `any` 타입을 사용하지 않고, 명확한 `React.MouseEvent<HTMLElement>` 타입을 사용하는 것이 적절하다고 생각했습니다.

## 🔊 도움이 필요한 부분
- `onClick` 핸들러 타입 지정 부분에서 코드 스타일이나 추가적인 개선 사항이 있는지 의견 부탁드립니다.