### PR TITLE
[EI-262] [api] feat: 가입시 빈 메타데이터 생성

### DIFF
--- a/apps/api/src/auth/auth.module.ts
+++ b/apps/api/src/auth/auth.module.ts
@@ -6,9 +6,10 @@ import { MemberEntity } from './entity/member.entity';
 import { PassportModule } from '@nestjs/passport';
 import { SupabaseStrategy } from './supabase/supabase.strategy';
 import { SupabaseService } from './supabase/supabase.service';
+import { CqrsModule } from '@nestjs/cqrs';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([MemberEntity]), PassportModule],
+  imports: [TypeOrmModule.forFeature([MemberEntity]), PassportModule, CqrsModule],
   controllers: [AuthController],
   providers: [AuthService, SupabaseService, SupabaseStrategy],
 })

--- a/apps/api/src/auth/test/E2E test/auth.e2e.spec.ts
+++ b/apps/api/src/auth/test/E2E test/auth.e2e.spec.ts
@@ -16,6 +16,7 @@ import { AuthService } from '../../application/auth.service';
 import { MockAuthGuard, mockAuthorization, mockUser } from '../data/mock-auth.guard';
 import { HttpExceptionFilter } from '../../../utils/exception-filter/http-exception-filter';
 import { UserCertificationDto } from '../../api/dto/response/user-certification.dto';
+import { CqrsModule } from '@nestjs/cqrs';
 
 jest.mock('@supabase/supabase-js', () => ({
   createClient: jest.fn(() => ({
@@ -75,6 +76,7 @@ describe('Auth E2E Test', () => {
               synchronize: true,
             }),
           }),
+          CqrsModule,
         ],
         controllers: [AuthController],
         providers: [


### PR DESCRIPTION
## ✅ 작업 내용
- 가입시 빈 메타데이터를 생성하는 코드를 추가했습니다.

## 🤔 고민 했던 부분
- commandBus 를 통해 메타데이터 생성을 요청해봤습니다.

## 🔊 도움이 필요한 부분
- 1개 미만으로 메타데이터를 삭제하는 로직은 PR분리를 해서 올리겠습니다. 도메인 이름이 워낙 복잡해서 시간이 좀 오래 걸리네요. ㅠ