### PR TITLE
[EI-263] [api] fix: 한 개 이하로 메타데이터를 삭제하지 못하도록 방지하는 코드 추가

### DIFF
--- a/apps/api/src/numerical-guidance/infrastructure/adapter/persistence/indicator-board-metadata/indicator-board-metadata.persistent.adapter.ts
+++ b/apps/api/src/numerical-guidance/infrastructure/adapter/persistence/indicator-board-metadata/indicator-board-metadata.persistent.adapter.ts
@@ -342,7 +342,12 @@ export class IndicatorBoardMetadataPersistentAdapter
   async deleteIndicatorBoardMetadata(id: string) {
     try {
       const indicatorBoardMetadataEntity: IndicatorBoardMetadataEntity =
-        await this.indicatorBoardMetadataRepository.findOneBy({ id: id });
+        await this.indicatorBoardMetadataRepository.findOne({
+          relations: ['member'],
+          where: {
+            id,
+          },
+        });
       this.nullCheckForEntity(indicatorBoardMetadataEntity);
 
       const { member } = indicatorBoardMetadataEntity;

--- a/apps/api/src/numerical-guidance/infrastructure/adapter/persistence/indicator-board-metadata/indicator-board-metadata.persistent.adapter.ts
+++ b/apps/api/src/numerical-guidance/infrastructure/adapter/persistence/indicator-board-metadata/indicator-board-metadata.persistent.adapter.ts
@@ -345,6 +345,12 @@ export class IndicatorBoardMetadataPersistentAdapter
         await this.indicatorBoardMetadataRepository.findOneBy({ id: id });
       this.nullCheckForEntity(indicatorBoardMetadataEntity);
 
+      const { member } = indicatorBoardMetadataEntity;
+      const metadatas = await this.loadIndicatorBoardMetadataList(member.id);
+      if (metadatas.length <= 1) {
+        throw new BadRequestException();
+      }
+
       await this.indicatorBoardMetadataRepository.remove(indicatorBoardMetadataEntity);
     } catch (error) {
       if (error instanceof NotFoundException) {
@@ -361,6 +367,13 @@ export class IndicatorBoardMetadataPersistentAdapter
           1. id 값이 uuid 형식을 잘 따르고 있는지 확인해주세요.`,
           message: '정보를 불러오는 중에 문제가 발생했습니다. 다시 시도해주세요.',
           cause: error,
+        });
+      } else if (error instanceof BadRequestException) {
+        throw new BadRequestException({
+          HttpStatus: HttpStatus.BAD_REQUEST,
+          error: `[ERROR] 지표보드 메타데이터를 삭제하는 도중에 entity 오류가 발생했습니다.
+          2. 메타데이터가 1개 미만으로 감소하는지 확인해주세요.`,
+          message: '정보를 불러오는 중에 문제가 발생했습니다. 다시 시도해주세요.',
         });
       } else {
         throw new InternalServerErrorException({


### PR DESCRIPTION
## ✅ 작업 내용
- deleteIndicatorBoardMetadata() 를 수정했습니다.

## 🤔 고민 했던 부분
- 처음에는 DeleteIndicatorBoardMetadataCommand 를 수정해서 구현해봤지만 생각보다 변경사항이 커져 
deleteIndicatorBoardMetadata 함수에 방어로직을 추가
## 🔊 도움이 필요한 부분
- 아직도 npm run test 하면 퍼지는 문제가 있음...