### PR TITLE
[MC-4] [web] feat: Add MiniChart component and integrate with ChartCard

### DIFF
--- a/apps/web/app/ui/components/domain/numerical-guidance/major-indicator/major-chart-card/major-indicator-card.tsx
+++ b/apps/web/app/ui/components/domain/numerical-guidance/major-indicator/major-chart-card/major-indicator-card.tsx
@@ -19,7 +19,7 @@ export default function MajorIndicatorCard({ country }: { country: string }) {
                   value: chartData.symbolPrice,
                   changeValue: chartData.symbolChanges,
                   countryFlag: `/public/assets/images/${chartData.country.toLowerCase()}.svg`,
-                  chart: <div className="flex items-center justify-center bg-gray-300">차트</div>,
+                  chartData: chartData.timeline,
                 }))}
               />
             </CarouselItem>

--- a/apps/web/app/ui/components/view/atom/mini-chart/mini-chart.stories.tsx
+++ b/apps/web/app/ui/components/view/atom/mini-chart/mini-chart.stories.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { Meta, StoryObj } from '@storybook/react';
+import MiniChart, { ChartTimeline } from './mini-chart';
+
+const meta: Meta<typeof MiniChart> = {
+  title: 'view/atom/MiniChart',
+  component: MiniChart,
+  argTypes: {
+    data: { control: 'object' },
+    className: { control: 'text' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof MiniChart>;
+
+const increasingTrendData: ChartTimeline[] = [
+  { time: '2024-09-06 15:55:00', value: 390.12 },
+  { time: '2024-09-06 16:00:00', value: 401.38 },
+  { time: '2024-09-06 16:05:00', value: 410.5 },
+  { time: '2024-09-06 16:10:00', value: 415.22 },
+  { time: '2024-09-06 16:15:00', value: 420.0 },
+  { time: '2024-09-06 16:20:00', value: 430.15 },
+  { time: '2024-09-06 16:25:00', value: 440.9 },
+];
+
+const decreasingTrendData: ChartTimeline[] = [
+  { time: '2024-09-06 15:55:00', value: 450.22 },
+  { time: '2024-09-06 16:00:00', value: 440.1 },
+  { time: '2024-09-06 16:05:00', value: 430.55 },
+  { time: '2024-09-06 16:10:00', value: 420.9 },
+  { time: '2024-09-06 16:15:00', value: 415.38 },
+  { time: '2024-09-06 16:20:00', value: 410.12 },
+  { time: '2024-09-06 16:25:00', value: 405.0 },
+];
+
+export const IncreasingTrend: Story = {
+  args: {
+    data: increasingTrendData,
+    className: 'w-64 h-32',
+  },
+};
+
+export const DecreasingTrend: Story = {
+  args: {
+    data: decreasingTrendData,
+    className: 'w-64 h-32',
+  },
+};

--- a/apps/web/app/ui/components/view/atom/mini-chart/mini-chart.tsx
+++ b/apps/web/app/ui/components/view/atom/mini-chart/mini-chart.tsx
@@ -8,7 +8,7 @@ interface ColoredLineChartProps {
   color: string;
 }
 
-const ColoredLineChart: React.FC<ColoredLineChartProps> = ({ data, color }) => {
+const ColoredLineChart = ({ data, color }: ColoredLineChartProps) => {
   return (
     <ResponsiveContainer width="100%" height="100%">
       <LineChart data={data}>

--- a/apps/web/app/ui/components/view/atom/mini-chart/mini-chart.tsx
+++ b/apps/web/app/ui/components/view/atom/mini-chart/mini-chart.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { LineChart, Line, ResponsiveContainer } from 'recharts';
+
+export type ChartTimeline = { time: string; value: number };
+
+interface ColoredLineChartProps {
+  data: ChartTimeline[];
+  color: string;
+}
+
+const ColoredLineChart: React.FC<ColoredLineChartProps> = ({ data, color }) => {
+  return (
+    <ResponsiveContainer width="100%" height="100%">
+      <LineChart data={data}>
+        <Line type="monotone" dataKey="value" stroke={color} strokeWidth={3} dot={false} />
+      </LineChart>
+    </ResponsiveContainer>
+  );
+};
+
+interface MiniChartProps {
+  data: ChartTimeline[];
+  className?: string;
+  isPositive: boolean;
+}
+
+const MiniChart: React.FC<MiniChartProps> = ({ data, className, isPositive }) => {
+  if (!data || data.length === 0) {
+    return <div className={className}>No data</div>;
+  }
+
+  const color = isPositive ? '#ef4444' : '#3b82f6';
+
+  return (
+    <div className={className}>
+      <ColoredLineChart data={data} color={color} />
+    </div>
+  );
+};
+
+export default MiniChart;

--- a/apps/web/app/ui/components/view/atom/mini-chart/mini-chart.tsx
+++ b/apps/web/app/ui/components/view/atom/mini-chart/mini-chart.tsx
@@ -24,7 +24,7 @@ interface MiniChartProps {
   isPositive: boolean;
 }
 
-const MiniChart: React.FC<MiniChartProps> = ({ data, className, isPositive }) => {
+const MiniChart = ({ data, className, isPositive }: MiniChartProps) => {
   if (!data || data.length === 0) {
     return <div className={className}>No data</div>;
   }

--- a/apps/web/app/ui/components/view/molecule/chart-card/chart-card.stories.tsx
+++ b/apps/web/app/ui/components/view/molecule/chart-card/chart-card.stories.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import Logo from '@/public/fingoo-logo.ico'; // Replace with your actual path to the flag image or icon
 import ChartCardGrid from './chart-card';
+import { ChartTimeline } from '../../atom/mini-chart/mini-chart';
 
 const meta: Meta<typeof ChartCardGrid> = {
   title: 'view/molecule/ChartCardGrid',
@@ -15,7 +16,25 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-const chartMock = <div style={{ backgroundColor: '#f0f0f0', height: '100%', width: '100%' }}>Chart</div>;
+const chartDataIncreasing: ChartTimeline[] = [
+  { time: '2024-09-06 15:55:00', value: 390.12 },
+  { time: '2024-09-06 16:00:00', value: 401.38 },
+  { time: '2024-09-06 16:05:00', value: 410.5 },
+  { time: '2024-09-06 16:10:00', value: 415.22 },
+  { time: '2024-09-06 16:15:00', value: 420.0 },
+  { time: '2024-09-06 16:20:00', value: 430.15 },
+  { time: '2024-09-06 16:25:00', value: 440.9 },
+];
+
+const chartDataDecreasing: ChartTimeline[] = [
+  { time: '2024-09-06 15:55:00', value: 450.22 },
+  { time: '2024-09-06 16:00:00', value: 440.1 },
+  { time: '2024-09-06 16:05:00', value: 430.55 },
+  { time: '2024-09-06 16:10:00', value: 420.9 },
+  { time: '2024-09-06 16:15:00', value: 415.38 },
+  { time: '2024-09-06 16:20:00', value: 410.12 },
+  { time: '2024-09-06 16:25:00', value: 405.0 },
+];
 
 const defaultData = [
   {
@@ -23,28 +42,28 @@ const defaultData = [
     value: 4200.45,
     changeValue: 1.25,
     countryFlag: Logo.src,
-    chart: chartMock,
+    chartData: chartDataIncreasing,
   },
   {
     indexName: 'Dow Jones',
     value: 34875.23,
     changeValue: -0.67,
     countryFlag: Logo.src,
-    chart: chartMock,
+    chartData: chartDataDecreasing,
   },
   {
     indexName: 'S&P 500',
     value: 4200.45,
     changeValue: 1.25,
     countryFlag: Logo.src,
-    chart: chartMock,
+    chartData: chartDataIncreasing,
   },
   {
     indexName: 'Dow Jones',
     value: 34875.23,
     changeValue: -0.67,
     countryFlag: Logo.src,
-    chart: chartMock,
+    chartData: chartDataDecreasing,
   },
 ];
 
@@ -62,14 +81,14 @@ export const WithNegativeChange: Story = {
         value: 13000.87,
         changeValue: -2.34,
         countryFlag: Logo.src,
-        chart: chartMock,
+        chartData: chartDataDecreasing,
       },
       {
         indexName: 'FTSE 100',
         value: 7200.55,
         changeValue: -0.89,
         countryFlag: Logo.src,
-        chart: chartMock,
+        chartData: chartDataDecreasing,
       },
     ],
   },
@@ -83,14 +102,14 @@ export const WithPositiveChange: Story = {
         value: 15600.33,
         changeValue: 1.12,
         countryFlag: Logo.src,
-        chart: chartMock,
+        chartData: chartDataIncreasing,
       },
       {
         indexName: 'CAC 40',
         value: 6700.44,
         changeValue: 0.45,
         countryFlag: Logo.src,
-        chart: chartMock,
+        chartData: chartDataIncreasing,
       },
     ],
   },

--- a/apps/web/app/ui/components/view/molecule/chart-card/chart-card.tsx
+++ b/apps/web/app/ui/components/view/molecule/chart-card/chart-card.tsx
@@ -16,17 +16,17 @@ interface IndexProps {
   data: ChartCardProps[];
 }
 
-const ValueDisplay: React.FC<{ value: number }> = ({ value }) => (
+const ValueDisplay = ({ value }: { value: number }) => (
   <div className="text-lg font-bold">
     {value.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
   </div>
 );
 
-const ChangeDisplay: React.FC<{ changeValue: number }> = ({ changeValue }) => (
+const ChangeDisplay = ({ changeValue }: { changeValue: number }) => (
   <div className="text-sm">{`${changeValue > 0 ? '+' : ''}${changeValue.toFixed(2)}%`}</div>
 );
 
-const ChartCard: React.FC<ChartCardProps> = ({ indexName, value, changeValue, countryFlag, chartData }) => {
+const ChartCard = ({ indexName, value, changeValue, countryFlag, chartData }: ChartCardProps) => {
   const isPositive = changeValue > 0;
   return (
     <Card className={'w-full rounded-sm'}>
@@ -47,7 +47,7 @@ const ChartCard: React.FC<ChartCardProps> = ({ indexName, value, changeValue, co
   );
 };
 
-const ChartCardGrid: React.FC<IndexProps> = ({ data }) => (
+const ChartCardGrid = ({ data }: IndexProps) => (
   <div className="grid grid-cols-2">
     {data.map((item, index) => (
       <ChartCard

--- a/apps/web/app/ui/components/view/molecule/chart-card/chart-card.tsx
+++ b/apps/web/app/ui/components/view/molecule/chart-card/chart-card.tsx
@@ -2,13 +2,14 @@ import * as React from 'react';
 import { cn } from '@/app/utils/style';
 import { Card, CardHeader, CardTitle, CardContent } from '../card/card';
 import Avatar from '../../atom/avatar/avatar';
+import MiniChart, { ChartTimeline } from '../../atom/mini-chart/mini-chart';
 
 interface ChartCardProps {
   indexName: string;
   value: number;
   changeValue: number;
   countryFlag: string;
-  chart: React.ReactNode;
+  chartData: ChartTimeline[];
 }
 
 interface IndexProps {
@@ -25,11 +26,7 @@ const ChangeDisplay: React.FC<{ changeValue: number }> = ({ changeValue }) => (
   <div className="text-sm">{`${changeValue > 0 ? '+' : ''}${changeValue.toFixed(2)}%`}</div>
 );
 
-const ChartImage: React.FC<{ chart: string | React.ReactNode }> = ({ chart }) => (
-  <div className="h-12 w-full">{chart}</div>
-);
-
-const ChartCard: React.FC<ChartCardProps> = ({ indexName, value, changeValue, countryFlag, chart }) => {
+const ChartCard: React.FC<ChartCardProps> = ({ indexName, value, changeValue, countryFlag, chartData }) => {
   const isPositive = changeValue > 0;
   return (
     <Card className={'w-full rounded-sm'}>
@@ -43,7 +40,7 @@ const ChartCard: React.FC<ChartCardProps> = ({ indexName, value, changeValue, co
             <ValueDisplay value={value} />
             <ChangeDisplay changeValue={changeValue} />
           </div>
-          <ChartImage chart={chart} />
+          <MiniChart data={chartData} className="h-12 w-14" isPositive={isPositive} />
         </div>
       </CardContent>
     </Card>
@@ -59,7 +56,7 @@ const ChartCardGrid: React.FC<IndexProps> = ({ data }) => (
         value={item.value}
         changeValue={item.changeValue}
         countryFlag={item.countryFlag}
-        chart={item.chart}
+        chartData={item.chartData}
       />
     ))}
   </div>


### PR DESCRIPTION
## ✅ 작업 내용
- MiniChart를 구현하고 ChartCard와 통합하였습니다.

## 🤔 고민 했던 부분
- 초기에는 MiniChart가 자체적으로 색상을 결정하도록 구현했으나, 준호님의 구현 사항을 반영하여 isPositive 값을 받아 색상을 결정하는 방식으로 변경했습니다.
- 차트의 stroke 컬러를 ChartCard에 사용된 컬러와 일치시키기 위해 헥스 코드를 사용했습니다.
- SparkChart라는 이름을 사용하려 했으나, 동일한 이름의 파일이 있어 MiniChart로 네이밍했습니다.