### PR TITLE
Mc 111 adsense login

### DIFF
--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -7,17 +7,17 @@ second_line=$(echo "$commit_msg" | sed -n '2p')
 
 if git diff --cached --name-only | grep -q "web"; then
    # web 경로가 포함되어 있으면, 해당 정보를 커밋 메시지에 추가
-  commit_msg_title_regex='^(\[web\]\s*)(feat|fix|refactor|chore|test|docs|style|rename): .{1,200}?$'
+  commit_msg_title_regex='^(\[web\]\s*)(feat|fix|refactor|chore|test|docs|style|rename): .+'
 elif git diff --cached --name-only | grep -q "api"; then
   # api 경로가 포함되어 있으면, 해당 정보를 커밋 메시지에 추가
-  commit_msg_title_regex='^(\[api\]\s*)(feat|fix|refactor|chore|test|docs|style|rename): .{1,200}?$'
+  commit_msg_title_regex='^(\[api\]\s*)(feat|fix|refactor|chore|test|docs|style|rename): .+'
 else
-  commit_msg_title_regex='^(\[infra\]\s*)(feat|fix|refactor|chore|test|docs|style|rename): .{1,200}?$'
+  commit_msg_title_regex='^(\[infra\]\s*)(feat|fix|refactor|chore|test|docs|style|rename): .+'
 fi
 
 # 제목
 if ! grep -qE "$commit_msg_title_regex" "$commit_msg_file"; then
-  echo "COMMIT REJECTED: { [api|web|infra] feat|fix|refactor|chore|test|docs|style|rename: commit 제목 } 제시된 형식에 맞게 작성해주세요."
+  echo "COMMIT REJECTED: { [api|web|infra] feat|fix|refactor|chore|test|docs|style|rename: commit 제목 } 제시된 형식에 맞게 작성해주세요"
   exit 1
 fi
 

--- a/apps/web/__tests__/business/hooks/indicator-board-metadata/use-selected-indicator-board-metadata-view-model.hook.test.tsx
+++ b/apps/web/__tests__/business/hooks/indicator-board-metadata/use-selected-indicator-board-metadata-view-model.hook.test.tsx
@@ -37,7 +37,7 @@ describe('useSelectedIndicatorBoardMetadata', () => {
     expect(result.current.selectedMetadata).toEqual(result.current.metadataList?.[0]);
   });
 
-  it('메타데이터를 선택하지 않으면, 선택한 메타데이터 값이 존재하지 않는다.', async () => {
+  it('메타데이터를 선택하지 않으면, 기본으로 0번째 메타데이터가 선택된다', async () => {
     // given
     const { result } = renderHook(() => {
       return {
@@ -54,10 +54,10 @@ describe('useSelectedIndicatorBoardMetadata', () => {
     });
 
     // then
-    expect(result.current.selectedMetadata).toBeUndefined();
+    expect(result.current.selectedMetadata).toEqual(result.current.metadataList?.[0]);
   });
 
-  it('메타데이터를 선택했다가 해제하면, 선택한 메타데이터 값이 존재하지 않는다.', async () => {
+  it('메타데이터를 선택했다가 해제하면, 기본으로 0번째 메타데이터가 선택된다.', async () => {
     // given
     const { result } = renderHook(() => {
       return {
@@ -70,18 +70,18 @@ describe('useSelectedIndicatorBoardMetadata', () => {
 
     // when
     act(() => {
-      if (result.current.metadataList?.[0]) {
-        result.current.actions.selectMetadata(result.current.metadataList?.[0].id);
+      if (result.current.metadataList?.[1]) {
+        result.current.actions.selectMetadata(result.current.metadataList?.[1].id);
       }
     });
     await waitFor(() => expect(result.current.selectedMetadata).not.toBeUndefined());
     act(() => {
       result.current.actions.selectMetadata(undefined);
     });
-    await waitFor(() => expect(result.current.selectedMetadata).toBeUndefined());
+    // await waitFor(() => expect(result.current.selectedMetadata).toBeUndefined());
 
     // then
-    expect(result.current.selectedMetadata).toBeUndefined();
+    expect(result.current.selectedMetadata).toEqual(result.current.metadataList?.[0]);
   });
 
   it('메타데이터를 선택했다가 다른 메타데이터를 선택하면, 마지막에 선택한 메타데이터 값을 가져온다', async () => {

--- a/apps/web/__tests__/components/numerical-guidance/indicator-board-metadata/metadata-list.test.tsx
+++ b/apps/web/__tests__/components/numerical-guidance/indicator-board-metadata/metadata-list.test.tsx
@@ -68,6 +68,19 @@ describe('MetadataList', () => {
     expect(await screen.findAllByText('메타데이터(1)'));
   });
 
+  it('사용자가 메타데이터를 선택하지 않아도, 기본으로 메타데이터가 선택된다', async () => {
+    // given
+    render(
+      <SWRProviderWithoutCache>
+        <MetadataList />
+      </SWRProviderWithoutCache>,
+    );
+
+    // when
+    // then
+    expect(await screen.findByRole('tab', { selected: true })).toBeInTheDocument();
+  });
+
   it('사용자가 메타데이터를 클릭하면, 메타데이터가 선택된다.', async () => {
     // given
     const user = userEvent.setup();
@@ -79,7 +92,6 @@ describe('MetadataList', () => {
     await waitFor(async () => expect(await screen.findByText(/metadata1/i)).toBeInTheDocument());
 
     // when
-    expect(screen.queryByRole('tab', { selected: true })).toBeNull();
     await user.click(await screen.findByText(/metadata1/i));
 
     // then

--- a/apps/web/app/business/hooks/numerical-guidance/indicator-board-metedata/use-selected-indicator-board-metadata-view-model.hook.ts
+++ b/apps/web/app/business/hooks/numerical-guidance/indicator-board-metedata/use-selected-indicator-board-metadata-view-model.hook.ts
@@ -25,7 +25,7 @@ export const useSelectedIndicatorBoardMetadata = () => {
   const { trigger: deleteCustomForecastIndicatorTrigger } =
     useDeleteCustomForecastIndicatorFromMetadata(selectedMetadataId);
 
-  const { addMetadataToIndicatorBoard, deleteMetadataFromIndicatorBoard } = useSplitIndicatorBoard();
+  const { addMetadataToIndicatorBoard } = useSplitIndicatorBoard();
 
   const convertedIndicatorBoardMetadataList = useMemo(() => {
     if (!indicatorBoardMetadataList) return undefined;
@@ -35,7 +35,12 @@ export const useSelectedIndicatorBoardMetadata = () => {
 
   useEffect(() => {
     if (!selectedMetadataId && convertedIndicatorBoardMetadataList?.formattedIndicatorBoardMetadataList.length) {
-      selectMetadataById(convertedIndicatorBoardMetadataList?.formattedIndicatorBoardMetadataList[0].id);
+      const isSuccess = addMetadataToIndicatorBoard(
+        convertedIndicatorBoardMetadataList?.formattedIndicatorBoardMetadataList[0].id,
+      );
+      if (isSuccess) {
+        selectMetadataById(convertedIndicatorBoardMetadataList?.formattedIndicatorBoardMetadataList[0].id);
+      }
     }
   }, [selectedMetadataId, convertedIndicatorBoardMetadataList]);
 
@@ -132,20 +137,10 @@ export const useSelectedIndicatorBoardMetadata = () => {
     );
   };
 
-  function selectMetadataById(metadataId: string) {
-    const isSuccess = addMetadataToIndicatorBoard(metadataId);
-    if (isSuccess) {
-      selectMetadata(metadataId);
-      activeTab();
-    }
-  }
+  function selectMetadataById(metadataId: string | undefined) {
+    selectMetadata(metadataId);
 
-  function unselectMetadataById(metadataId: string) {
-    const isSelected = selectedMetadata?.id === metadataId;
-    deleteMetadataFromIndicatorBoard(metadataId);
-    if (isSelected) {
-      selectMetadata(undefined);
-    }
+    activeTab();
   }
 
   return {
@@ -156,6 +151,5 @@ export const useSelectedIndicatorBoardMetadata = () => {
     addCustomForecastIndicatorToMetadata,
     selectMetadataById,
     deleteCustomForecastIndicatorFromMetadata,
-    unselectMetadataById,
   };
 };

--- a/apps/web/app/business/hooks/numerical-guidance/indicator-board/use-indicator-board.hook.ts
+++ b/apps/web/app/business/hooks/numerical-guidance/indicator-board/use-indicator-board.hook.ts
@@ -35,10 +35,6 @@ export const useIndicatorBoard = (indicatorBoardMetadataId?: string) => {
     updateIndicatorBoardInfo(indicatorBoardMetadataId, { dateRange });
   }
 
-  function deleteMetadataFromIndicatorBoard(metadataId: string) {
-    deleteIndicatorBoardInfo(metadataId);
-  }
-
   return {
     indicatorBoardInfos,
     indicatorBoardInfo,
@@ -48,7 +44,6 @@ export const useIndicatorBoard = (indicatorBoardMetadataId?: string) => {
     setIsAdvancedChart,
     setInterval,
     checkMetadataInIndicatorBoard,
-    deleteMetadataFromIndicatorBoard,
     updateDateRange,
   };
 };

--- a/apps/web/app/business/hooks/numerical-guidance/indicator-board/use-split-indicator-board.hook.ts
+++ b/apps/web/app/business/hooks/numerical-guidance/indicator-board/use-split-indicator-board.hook.ts
@@ -15,6 +15,7 @@ export const useSplitIndicatorBoard = () => {
     sliceIndicatorBoardInfos,
     setSplitScreen,
     setActiveDragMetadataId,
+    deleteIndicatorBoardInfo,
   } = useIndicatorBoardStore((state) => state.actions);
 
   const selectedMetadataId = useWorkspaceStore((state) => state.selectedMetadataId);
@@ -64,6 +65,10 @@ export const useSplitIndicatorBoard = () => {
     return false;
   }
 
+  function deleteMetadataFromIndicatorBoard(metadataId: string) {
+    deleteIndicatorBoardInfo(metadataId);
+  }
+
   const handleDragSwapWithOtherContext = (newValue: { [key: string]: string[] }) => {
     const newIndicatorBoardMetadataIds = Object.keys(newValue).map((_, index) => newValue[`${index}`][0]);
     reorderIndicatorBoardInfos(newIndicatorBoardMetadataIds);
@@ -83,6 +88,7 @@ export const useSplitIndicatorBoard = () => {
     addMetadataToIndicatorBoard,
     handleActiveChange,
     handleDragSwapWithOtherContext,
+    deleteMetadataFromIndicatorBoard,
   };
 };
 

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -3,6 +3,12 @@ import './globals.css';
 import { cn } from './utils/style';
 import localFont from 'next/font/local';
 import GoogleAnalyticsProvider from './logging/provider/google-analytics-provider';
+import MockingUser from './ui/components/util/mocking-user';
+import ChatAiNavigator from './ui/pages/workspace/chat-ai-navigator';
+import FloatingComponentContainer from './ui/pages/workspace/floating-component-container';
+import SideNav from './ui/pages/workspace/side-bar/sidenav';
+import { SWRProvider } from './ui/components/util/swr-provider';
+import ChatProvider from './business/hooks/linguistic-guidance/provider/chat-provider';
 
 const myFont = localFont({
   src: './PretendardVariable.woff2',
@@ -22,7 +28,20 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       className="scrollbar-track-white scrollbar-thumb-slate-200 scrollbar-track-rounded-full scrollbar-thumb-rounded-full scrollbar-w-1.5"
     >
       <GoogleAnalyticsProvider>
-        <body className={cn(myFont.variable, 'font-pretendard')}>{children}</body>
+        <body className={cn(myFont.variable, 'font-pretendard')}>
+          <ChatProvider>
+            <MockingUser>
+              <SWRProvider>
+                <div className="flex h-screen md:flex-row md:overflow-hidden">
+                  <SideNav />
+                  <div className="grow bg-fingoo-gray-1.5">{children}</div>
+                  <ChatAiNavigator />
+                  <FloatingComponentContainer />
+                </div>
+              </SWRProvider>
+            </MockingUser>
+          </ChatProvider>
+        </body>
       </GoogleAnalyticsProvider>
     </html>
   );

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -3,8 +3,23 @@ import Link from 'next/link';
 import { CardContent, CardFooter, Card } from '@/app/ui/components/view/molecule/card/card';
 import Form from './ui/components/view/molecule/form';
 import { authenticate } from './business/services/auth/sign-in.service';
+import SplitScreenToggleGroup from './ui/pages/workspace/split-screen/split-screen-toggle-group';
+import Workspace from './ui/pages/workspace/workspace';
 
 export default function Page() {
+  return (
+    <div className="relative h-full w-full">
+      <div className="absolute left-1/2 top-2 z-10 -translate-x-1/2 rounded-lg ">
+        <SplitScreenToggleGroup />
+      </div>
+      <div className="flex h-full items-center justify-center">
+        <Workspace />
+      </div>
+    </div>
+  );
+}
+
+function LoginFormPage() {
   return (
     <div className="flex min-h-[100dvh] items-center justify-center bg-gray-100 px-4 dark:bg-gray-950">
       <div className="w-full max-w-md space-y-6">

--- a/apps/web/app/ui/components/domain/numerical-guidance/indicator-board-metadata/metadata-list-item/metadata-list-item.tsx
+++ b/apps/web/app/ui/components/domain/numerical-guidance/indicator-board-metadata/metadata-list-item/metadata-list-item.tsx
@@ -15,6 +15,7 @@ import { useIndicatorBoard } from '@/app/business/hooks/numerical-guidance/indic
 import MetadataListItemRow from './metadata-list-item-row';
 import { useLogger } from '@/app/logging/use-logger.hook';
 import MetadataListItemDraggableRow from './metadata-list-item-draggable-row';
+import { useSplitIndicatorBoard } from '@/app/business/hooks/numerical-guidance/indicator-board/use-split-indicator-board.hook';
 
 type MetadataListItemProps = {
   item: IndicatorBoardMetadata;
@@ -26,11 +27,13 @@ export default function MetadataListItem({ item }: MetadataListItemProps) {
 
   const [activeDragItemId, setActiveDragItemId] = useState<string | null>(null);
   const { dialogPositionRef: iconButtonRef, openDialogWithPayload } = useDialog(DIALOG_KEY.METADATA_EDIT_MENU);
-  const { selectedMetadata, selectMetadataById, unselectMetadataById } = useSelectedIndicatorBoardMetadata();
+  const { selectedMetadata, selectMetadataById } = useSelectedIndicatorBoardMetadata();
   const { indicatorBoardMetadata, updateIndicatorIdsWithsectionIds } = useIndicatorBoardMetadataViewModel(item.id);
   const [indicatorIdsWithSectionIds, setIndicatorIdsWithsectionIds] = useState<{ [key: string]: string[] } | undefined>(
     indicatorBoardMetadata?.indicatorIdsWithSectionIds,
   );
+
+  const { addMetadataToIndicatorBoard, deleteMetadataFromIndicatorBoard } = useSplitIndicatorBoard();
 
   const { checkMetadataInIndicatorBoard } = useIndicatorBoard(item.id);
 
@@ -52,11 +55,17 @@ export default function MetadataListItem({ item }: MetadataListItemProps) {
     logger.track('click_metadata_item', {
       value: item.id,
     });
-    selectMetadataById(item.id);
+    const isSuccess = addMetadataToIndicatorBoard(item.id);
+    if (isSuccess) {
+      selectMetadataById(item.id);
+    }
   };
 
   const handleDeSelect = () => {
-    unselectMetadataById(item.id);
+    deleteMetadataFromIndicatorBoard(item.id);
+    if (isSelected) {
+      selectMetadataById(undefined);
+    }
   };
 
   const handleIconButton = () => {

--- a/apps/web/app/ui/components/domain/numerical-guidance/indicator-board-metadata/metadata-list-item/metadata-list-item.tsx
+++ b/apps/web/app/ui/components/domain/numerical-guidance/indicator-board-metadata/metadata-list-item/metadata-list-item.tsx
@@ -14,9 +14,7 @@ import { cn } from '@/app/utils/style';
 import { useIndicatorBoard } from '@/app/business/hooks/numerical-guidance/indicator-board/use-indicator-board.hook';
 import MetadataListItemRow from './metadata-list-item-row';
 import { useLogger } from '@/app/logging/use-logger.hook';
-import { sendGAEvent } from '@next/third-parties/google';
 import MetadataListItemDraggableRow from './metadata-list-item-draggable-row';
-import { useSplitIndicatorBoard } from '@/app/business/hooks/numerical-guidance/indicator-board/use-split-indicator-board.hook';
 
 type MetadataListItemProps = {
   item: IndicatorBoardMetadata;
@@ -28,15 +26,13 @@ export default function MetadataListItem({ item }: MetadataListItemProps) {
 
   const [activeDragItemId, setActiveDragItemId] = useState<string | null>(null);
   const { dialogPositionRef: iconButtonRef, openDialogWithPayload } = useDialog(DIALOG_KEY.METADATA_EDIT_MENU);
-  const { selectedMetadata, selectMetadataById } = useSelectedIndicatorBoardMetadata();
+  const { selectedMetadata, selectMetadataById, unselectMetadataById } = useSelectedIndicatorBoardMetadata();
   const { indicatorBoardMetadata, updateIndicatorIdsWithsectionIds } = useIndicatorBoardMetadataViewModel(item.id);
   const [indicatorIdsWithSectionIds, setIndicatorIdsWithsectionIds] = useState<{ [key: string]: string[] } | undefined>(
     indicatorBoardMetadata?.indicatorIdsWithSectionIds,
   );
 
-  const { checkMetadataInIndicatorBoard, deleteMetadataFromIndicatorBoard } = useIndicatorBoard(item.id);
-
-  const { addMetadataToIndicatorBoard } = useSplitIndicatorBoard();
+  const { checkMetadataInIndicatorBoard } = useIndicatorBoard(item.id);
 
   useEffect(() => {
     setIndicatorIdsWithsectionIds(indicatorBoardMetadata?.indicatorIdsWithSectionIds);
@@ -56,17 +52,11 @@ export default function MetadataListItem({ item }: MetadataListItemProps) {
     logger.track('click_metadata_item', {
       value: item.id,
     });
-    const isSuccess = addMetadataToIndicatorBoard(item.id);
-    if (isSuccess) {
-      selectMetadataById(item.id);
-    }
+    selectMetadataById(item.id);
   };
 
   const handleDeSelect = () => {
-    deleteMetadataFromIndicatorBoard(item.id);
-    if (isSelected) {
-      selectMetadataById(undefined);
-    }
+    unselectMetadataById(item.id);
   };
 
   const handleIconButton = () => {

--- a/apps/web/app/ui/components/util/mocking-user.tsx
+++ b/apps/web/app/ui/components/util/mocking-user.tsx
@@ -1,0 +1,39 @@
+'use client';
+import { API_PATH } from '@/app/store/querys/api-path';
+import { useEffect, useState } from 'react';
+import Cookies from 'js-cookie';
+
+export default function MockingUser({ children }: React.PropsWithChildren) {
+  const [init, setInit] = useState(false);
+
+  useEffect(() => {
+    async function enableMocking() {
+      if (typeof window !== 'undefined') {
+        const response = await fetch(`${API_PATH.auth}/signIn`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            email: 'admin@test.com',
+            password: '123456',
+          }),
+        });
+
+        console.log(response);
+        const result = await response.json();
+        // console.log(result);
+        Cookies.set('accessToken', result.accessToken, {
+          secure: true,
+          path: '/',
+        });
+
+        setInit(true);
+      }
+    }
+
+    enableMocking();
+  }, []);
+
+  return <>{init ? children : null}</>;
+}


### PR DESCRIPTION
## ✅ 작업 내용
- 한글 커밋 메시지 사용 시 허스키에 의해 간헐적으로 차단되던 문제 해결
- 첫 화면 로딩 시 메타데이터가 항상 선택되도록 로직 개선
- 수정된 로직에 맞춰 테스트 케이스 업데이트
- 구글 애드센스 등록을 위한 사용자 로그인 상황 모킹 환경 구축
- 관련 코드 리팩토링 완료

## 🤔 고민 했던 부분
- 메타데이터를 기본으로 선택하게 하는 로직에서, 첫 로딩 시에만 적용할지, 선택된 메타데이터가 없을 때 기본값으로 첫 번째 메타데이터를 계속 유지할지 고민했습니다. 결국 항상 메타데이터를 선택하고 있도록 개발했습니다. 이유는 다음과 같습니다:
    - 메타데이터가 필수적인 요소라는 점을 더욱 부각시키고자 했습니다.
    - 메타데이터가 선택되지 않으면 GPT의 기능 대부분이 동작하지 않는데, 이러한 오류를 최소화하고자 했습니다.
    - 일반 사용자가 메타데이터를 1개만 가지게 된다면, 선택을 해제할 수 없는 이 방식이 더 적합할 것 같다고 판단했습니다.
