### PR TITLE
[MC-26] [web] refactor: improve login error handling logic and reassi…

### DIFF
--- a/apps/web/app/business/hooks/numerical-guidance/indicator-board-metedata/use-indicator-board-metadata-view-model.hook.ts
+++ b/apps/web/app/business/hooks/numerical-guidance/indicator-board-metedata/use-indicator-board-metadata-view-model.hook.ts
@@ -33,6 +33,7 @@ export const useIndicatorBoardMetadataViewModel = (metadataId: string | undefine
     ? convertedIndicatorBoardMetadataList?.findIndicatorBoardMetadataById(metadataId)
     : undefined;
 
+  const optimisticRevalidate = { revalidate: false };
   const updateIndicatorBoardMetadata = (newData: { name: string }) => {
     updateIndicatorBoardMetadataTrigger(
       {
@@ -44,7 +45,7 @@ export const useIndicatorBoardMetadataViewModel = (metadataId: string | undefine
             convertedIndicatorBoardMetadataList?.updateIndicatorBoardMetadataNameById(metadataId, newData.name);
           return newIndicatorBoardMetadataList?.formattedIndicatorBoardMetadataList;
         },
-        revalidate: false,
+        ...optimisticRevalidate,
       },
     );
   };
@@ -62,7 +63,7 @@ export const useIndicatorBoardMetadataViewModel = (metadataId: string | undefine
           );
           return newIndicatorBoardMetadataList?.formattedIndicatorBoardMetadataList;
         },
-        revalidate: false,
+        ...optimisticRevalidate,
       },
     );
   };
@@ -80,7 +81,7 @@ export const useIndicatorBoardMetadataViewModel = (metadataId: string | undefine
             convertedIndicatorBoardMetadataList?.addSectionToIndicatorBoardMetadata(metadataId);
           return newIndicatorBoardMetadataList?.formattedIndicatorBoardMetadataList;
         },
-        revalidate: false,
+        ...optimisticRevalidate,
       },
     );
   };
@@ -99,7 +100,7 @@ export const useIndicatorBoardMetadataViewModel = (metadataId: string | undefine
 
           return newIndicatorBoardMetadataList?.formattedIndicatorBoardMetadataList;
         },
-        revalidate: false,
+        ...optimisticRevalidate,
       },
     );
   };
@@ -121,7 +122,7 @@ export const useIndicatorBoardMetadataViewModel = (metadataId: string | undefine
           );
           return newIndicatorBoardMetadataList?.formattedIndicatorBoardMetadataList;
         },
-        revalidate: false,
+        ...optimisticRevalidate,
       },
     );
   };
@@ -130,7 +131,7 @@ export const useIndicatorBoardMetadataViewModel = (metadataId: string | undefine
     const formData = new FormData();
     formData.append('fileName', imageBlod);
     return await uploadIndicatorBoardMetadataImageTrigger(formData, {
-      revalidate: false,
+      ...optimisticRevalidate,
     });
   };
 

--- a/apps/web/app/business/hooks/numerical-guidance/indicator-board-metedata/use-selected-indicator-board-metadata-view-model.hook.ts
+++ b/apps/web/app/business/hooks/numerical-guidance/indicator-board-metedata/use-selected-indicator-board-metadata-view-model.hook.ts
@@ -49,6 +49,8 @@ export const useSelectedIndicatorBoardMetadata = () => {
     return convertedIndicatorBoardMetadataList?.findIndicatorBoardMetadataById(selectedMetadataId);
   }, [selectedMetadataId, convertedIndicatorBoardMetadataList]);
 
+  const optimisticRevalidate = { revalidate: false };
+
   const addIndicatorToMetadata = (indicatorInfo: IndicatorInfoResponse) => {
     if (!selectedMetadata) {
       return;
@@ -64,7 +66,7 @@ export const useSelectedIndicatorBoardMetadata = () => {
           );
           return newIndicatorBoardMetadataList?.formattedIndicatorBoardMetadataList;
         },
-        revalidate: false,
+        ...optimisticRevalidate,
       },
     );
   };
@@ -87,7 +89,7 @@ export const useSelectedIndicatorBoardMetadata = () => {
             );
           return newIndicatorBoardMetadataList?.formattedIndicatorBoardMetadataList;
         },
-        revalidate: false,
+        ...optimisticRevalidate,
       },
     );
   };
@@ -109,7 +111,7 @@ export const useSelectedIndicatorBoardMetadata = () => {
           );
           return newIndicatorBoardMetadataList?.formattedIndicatorBoardMetadataList;
         },
-        revalidate: false,
+        ...optimisticRevalidate,
       },
     );
   };
@@ -132,7 +134,7 @@ export const useSelectedIndicatorBoardMetadata = () => {
             );
           return newIndicatorBoardMetadataList?.formattedIndicatorBoardMetadataList;
         },
-        revalidate: false,
+        ...optimisticRevalidate,
       },
     );
   };

--- a/apps/web/app/business/hooks/post/use-post-list.hook.ts
+++ b/apps/web/app/business/hooks/post/use-post-list.hook.ts
@@ -1,0 +1,22 @@
+import { useFetchPostList } from '@/app/store/querys/post-list.query';
+import { useMemo } from 'react';
+import { convertPostViewModel } from '../../services/post/view-model/post-view-model.service';
+
+export const usePostyList = () => {
+  const { data: communityList, setSize } = useFetchPostList();
+  const convertedCommunityList = useMemo(() => {
+    if (!communityList) return undefined;
+    return communityList
+      .map((communityList) => {
+        return convertPostViewModel(communityList.data);
+      })
+      .flat();
+  }, [communityList]);
+  const loadMoreIndicators = () => {
+    setSize((size) => size + 1);
+  };
+  return {
+    indicatorList: convertedCommunityList,
+    loadMoreIndicators,
+  };
+};

--- a/apps/web/app/business/services/auth/auth-validation.service.ts
+++ b/apps/web/app/business/services/auth/auth-validation.service.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
 export const SignInFormSchema = z.object({
-  email: z.string(),
+  email: z.string().email(),
   password: z.string(),
 });
 

--- a/apps/web/app/business/services/auth/sign-in.service.ts
+++ b/apps/web/app/business/services/auth/sign-in.service.ts
@@ -25,6 +25,14 @@ export async function authenticate(prevState: FormState, formData: FormData): Pr
     ...validatedFields.data,
   };
 
+  // 잘못된 요청 처리 로직
+  const failureResponse = (message: string): FormState => ({
+    isSuccess: false,
+    isFailure: true,
+    validationError: {},
+    message,
+  });
+
   try {
     const response = await fetch(`${API_PATH.auth}/signIn`, {
       method: 'POST',
@@ -50,12 +58,7 @@ export async function authenticate(prevState: FormState, formData: FormData): Pr
     console.log(error);
     if (error instanceof HttpError && error.statusCode === 404) {
       // 잘못된 요청 처리 로직
-      return {
-        isSuccess: false,
-        isFailure: true,
-        validationError: {},
-        message: '로그인에 실패했습니다. 아이디와 비밀번호를 확인해주세요',
-      };
+      return failureResponse('로그인에 실패했습니다. 아이디와 비밀번호를 확인해주세요');
     } else {
       throw error;
     }

--- a/apps/web/app/business/services/post/view-model/post-list/post.service.ts
+++ b/apps/web/app/business/services/post/view-model/post-list/post.service.ts
@@ -1,0 +1,55 @@
+import { PostResponse } from '@/app/store/querys/post-list.query';
+
+export class Post {
+  readonly id: string;
+  readonly authorName: string;
+  readonly profileImageUrl: string | null;
+  readonly content: string;
+  readonly imageUrl?: string;
+  readonly createdAt: string;
+  readonly likeCount: number;
+  readonly commentCount: number;
+  readonly shareCount: number;
+  readonly hasUserLiked: boolean;
+
+  constructor({
+    id,
+    author,
+    content,
+    imageUrl,
+    createdAt,
+    likeCount,
+    commentCount,
+    shareCount,
+    hasUserLiked,
+  }: PostResponse) {
+    this.id = id;
+    this.authorName = author.userName;
+    this.profileImageUrl = author.profileImageUrl;
+    this.content = content;
+    this.imageUrl = imageUrl;
+    this.createdAt = createdAt;
+    this.likeCount = likeCount;
+    this.commentCount = commentCount;
+    this.shareCount = shareCount;
+    this.hasUserLiked = hasUserLiked;
+  }
+
+  get formattedPost(): PostResponse {
+    return {
+      id: this.id,
+      author: {
+        id: this.id,
+        userName: this.authorName,
+        profileImageUrl: this.profileImageUrl,
+      },
+      content: this.content,
+      imageUrl: this.imageUrl,
+      createdAt: this.createdAt,
+      likeCount: this.likeCount,
+      commentCount: this.commentCount,
+      shareCount: this.shareCount,
+      hasUserLiked: this.hasUserLiked,
+    };
+  }
+}

--- a/apps/web/app/business/services/post/view-model/post-view-model.service.ts
+++ b/apps/web/app/business/services/post/view-model/post-view-model.service.ts
@@ -1,0 +1,6 @@
+import { PostResponse } from '@/app/store/querys/post-list.query';
+import { Post } from './post-list/post.service';
+
+export function convertPostViewModel(data: PostResponse[]): Post[] {
+  return data.map((post) => new Post(post));
+}

--- a/apps/web/app/mocks/handlers/post-list-handler.mock.ts
+++ b/apps/web/app/mocks/handlers/post-list-handler.mock.ts
@@ -1,0 +1,4 @@
+import { http } from 'msw';
+import { API_PATH } from '@/app/store/querys/api-path';
+// MC-19 포스트 리스트 구현
+export const postListHandlers = [http.get(`${API_PATH.postList}`, async () => {})];

--- a/apps/web/app/store/querys/api-path.ts
+++ b/apps/web/app/store/querys/api-path.ts
@@ -14,4 +14,5 @@ export const API_PATH = {
   historyIndicatorsValue: `${API_URL}/numerical-guidance/indicators/history`,
   indicatorQuote: `${API_URL}/numerical-guidance/indicators/quote`,
   majorChart: `${API_URL}/major-chart`,
+  postList: `${API_URL}/community/post`,
 };

--- a/apps/web/app/store/querys/post-list.query.ts
+++ b/apps/web/app/store/querys/post-list.query.ts
@@ -1,0 +1,54 @@
+import useSWRInfinite from 'swr/infinite';
+import { API_PATH } from './api-path';
+import { defaultFetcher } from './fetcher';
+
+// 사용자 정보 타입 정의
+export type User = {
+  id: string; // 사용자 고유 ID
+  userName: string; // 사용자 이름
+  profileImageUrl: string | null; // 프로필 이미지 URL (null일 수 있음)
+};
+
+// 게시물 정보 타입 정의
+export type PostResponse = {
+  id: string; // 게시물 고유 ID
+  author: User; // 게시물 작성자 정보
+  content: string; // 게시물 내용
+  imageUrl?: string; // 게시물에 포함된 이미지 URL (선택적)
+  createdAt: string; // 게시물 작성 시간 (ISO 포맷의 문자열)
+  likeCount: number; // 좋아요 수
+  commentCount: number; // 댓글 수
+  shareCount: number; // 공유 수
+  hasUserLiked: boolean; // 사용자가 이 게시물에 좋아요를 눌렀는지 여부
+};
+
+type PaginationMeta = {
+  total: number;
+  hasNextData: boolean;
+  cursor: number;
+};
+
+export type PostListResponse = {
+  data: PostResponse[];
+  meta: PaginationMeta;
+};
+
+export const createKeyMakerIndicatorListInfinite = () => {
+  return (pageIndex: number, previousPageData: PostListResponse) => {
+    // 끝에 도달
+    if (previousPageData && !previousPageData.meta.hasNextData) return null;
+
+    // 첫 페이지, `previousPageData`가 없음
+    if (pageIndex === 0) return `${API_PATH.postList}/list?cursorToken=1`;
+
+    // API의 엔드포인트에 커서를 추가
+    return `${API_PATH.postList}/list?cursorToken=${previousPageData.meta.cursor}`;
+  };
+};
+
+// 최신순(?)에 의한 데이터 무한스크롤 패칭
+export const useFetchPostList = () => {
+  return useSWRInfinite<PostListResponse>(createKeyMakerIndicatorListInfinite(), defaultFetcher);
+};
+
+export const useFetchPost = () => {};


### PR DESCRIPTION
…gn variables

## ✅ 작업 내용
- sign-in.service에 authenticate 부분에서 잘못된 처리 로직 함수로 분기 및 잘못된 처리 후 FormState 반환으로 변경
- useIndicatorBoardMetadataViewModel훅과 useSelectedIndicatorBoardMetadata훅에서 낙관적 업데이트의 revalidate 옵션을 변수로 분기
- zod를 사용하는 SignInFormSchema에서 email부분에 .email()추가하여 email양식인지 확인하는 로직을 추가

## 🤔 고민 했던 부분
- sign-in.service의 authenticate 부분:
이 부분에서의 고민은 잘못된 요청 처리시 반환되는 객체의 타입을 지정해줄 필요가 있다고 느꼈습니다. 그래서 FormState와 동일한 속성들을 객체로 반환하고 있기 때문에 Formstate를 반환한다고 작성했고 추후 확장성과 유지보수를 위해 'failureResponse'라는 변수로 객체 타입을 분기 했습니다.
- useIndicatorBoardMetadataViewModel 및 useSelectedIndicatorBoardMetadata 훅:
낙관적 업데이트에 대한 revalidate 옵션에 대해서 낙관적 업데이트 상황에서 revalidate를 false로 지정해주고 있기 때문에, 이 옵션을 알기 쉽게
'optimisticRevalidate'라는 변수에 할당해 분기했습니다.
- SignInFormSchema의 email부분
이메일 형식을 검증하는 부분에서 Zod의 .email() 메서드를 추가하여 간결하게 해결하려 했지만, "이메일 형식 검증만으로 충분한지", "더 복잡한 규칙이 필요한지"에 대한 고민이 필요할 것 같습니다. 예를 들어, 특정 도메인 형식만 허용할지, 혹은 추가적인 검증이 필요한지 고려해볼 필요가 있을 것 같습니다. 추가적으로 password도 현재는 단순히 string 형식인지만 확인하고 있지만 대소문자나 특수문자 등을 추가해야할지 고려해볼 필요도 있을 것 같습니다.

## 🔊 도움이 필요한 부분