### PR TITLE
[MC-15] [api] feat: community의 게시글 삭제

### DIFF
--- a/apps/api/src/community/application/command/post/delete-post/delete-post.command.handler.ts
+++ b/apps/api/src/community/application/command/post/delete-post/delete-post.command.handler.ts
@@ -1,0 +1,15 @@
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+import { Inject, Injectable } from '@nestjs/common';
+import { DeletePostCommand } from './delete-post.command';
+import { DeletePostPort } from '../../../port/persistence/post/delete-post.port';
+
+@Injectable()
+@CommandHandler(DeletePostCommand)
+export class DeletePostCommandHandler implements ICommandHandler {
+  constructor(@Inject('DeletePostPort') private readonly deletePostPort: DeletePostPort) {}
+
+  async execute(command: DeletePostCommand): Promise<boolean> {
+    const { postId, userId } = command;
+    return this.deletePostPort.deletePost(postId, userId);
+  }
+}

--- a/apps/api/src/community/application/port/persistence/post/delete-post.port.ts
+++ b/apps/api/src/community/application/port/persistence/post/delete-post.port.ts
@@ -1,3 +1,3 @@
-export class DeletePostPort {
+export interface DeletePostPort {
   deletePost(postId, userId): Promise<boolean>;
 }

--- a/apps/api/src/community/application/port/persistence/post/delete-post.port.ts
+++ b/apps/api/src/community/application/port/persistence/post/delete-post.port.ts
@@ -1,3 +1,3 @@
-// export class DeletePostPort {
-//   deletePost(postId, userId): Promise<boolean>;
-// }
+export class DeletePostPort {
+  deletePost(postId, userId): Promise<boolean>;
+}

--- a/apps/api/src/community/application/port/persistence/post/update-post.port.ts
+++ b/apps/api/src/community/application/port/persistence/post/update-post.port.ts
@@ -1,5 +1,5 @@
 import { PostDomain } from '../../../../domain/post.domain';
 
-export class UpdatePostPort {
+export interface UpdatePostPort {
   updatePost(postId, content, userId): Promise<PostDomain>;
 }

--- a/apps/api/src/community/test/unit-test/application/command/delete-post.command.handler.spec.ts
+++ b/apps/api/src/community/test/unit-test/application/command/delete-post.command.handler.spec.ts
@@ -1,0 +1,72 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { CommunityPersistentAdapter } from '../../../../infrastructure/adapter/persistence/community.persistent.adapter';
+import { PostEntity } from '../../../../infrastructure/adapter/persistence/entity/post.entity';
+import { mockPostData1 } from '../../../data/mock-post.data1';
+import { mockUserMetadataData1 } from '../../../../../user/test/data/mock-user.metadata.data1';
+import { mockUserMetadataData2 } from '../../../../../user/test/data/mock-user.metadata.data2';
+import { mockPostData2 } from '../../../data/mock-post.data2';
+import { DeletePostPort } from '../../../../application/port/persistence/post/delete-post.port';
+import { UserMetadataEntity } from '../../../../../user/infrastructure/adapter/persistence/entity/user-metadata.entity';
+
+describe('DeletePost', () => {
+  let deletePostPort: DeletePostPort;
+  const mockPostRepository = {
+    find: jest.fn(),
+    findOne: jest.fn().mockImplementation(({ where: { id } }) => {
+      if (id === mockPostData1.id) {
+        return mockPostData1;
+      }
+      return null;
+    }),
+    save: jest.fn(),
+    remove: jest.fn().mockImplementation((postEntity: PostEntity) => {
+      return postEntity;
+    }),
+  };
+  const mockUserMetadataRepository = {
+    find: jest.fn(),
+    findOne: jest.fn(),
+    save: jest.fn(),
+    delete: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        {
+          provide: 'DeletePostPort',
+          useClass: CommunityPersistentAdapter,
+        },
+        {
+          provide: getRepositoryToken(PostEntity),
+          useValue: mockPostRepository,
+        },
+        {
+          provide: getRepositoryToken(UserMetadataEntity),
+          useValue: mockUserMetadataRepository,
+        },
+      ],
+    }).compile();
+    deletePostPort = await module.resolve<DeletePostPort>('DeletePostPort');
+  });
+
+  describe('Persistent', () => {
+    it('없는 게시글 가져오기', async () => {
+      await expect(deletePostPort.deletePost(mockPostData2.id, mockUserMetadataData1.userId)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('인가되지 않은 사용자 삭제', async () => {
+      await expect(deletePostPort.deletePost(mockPostData1.id, mockUserMetadataData2.userId)).rejects.toThrow(
+        ForbiddenException,
+      );
+    });
+
+    it('게시글 삭제 완료', async () => {
+      expect(await deletePostPort.deletePost(mockPostData1.id, mockUserMetadataData1.userId)).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## ✅ 작업 내용
- community 도메인에서 게시글을 삭제하는 기능을 추가하였습니다.

## 🤔 고민 했던 부분
- 이건 따로 트랜잭션 처리를 하지 않아도 될 정도로 간단한 기능이라 트랜잭션을 적용하진 않았습니다.
- 그리고 지금 PostEntity가 supabase의 User와 관계를 맺고 있는데 ORM에서 제공하는 cascade 기능을 사용할 수가 없겠더라구요... ORM에 있는 cascade 기능은 저희가 작성한 UserEntity가 따로 존재해야해서 불가할 것 같습니다. 때문에 사용자가 계정 탈퇴를 한다고 해서 게시글이 사라지는 것은 아닙니다. 그대로 남아있게 되어요! 그래서 supabase DB에 테이블을 생성하면서 제가 cascade 기능을 추가한 SQL 테이블 생성문을 작성해서 해결하겠습니다.
- 마지막으로 UserMetadataEntity와 연결지으면 안되냐라고 물으실 수도 있을 것 같습니다. UserMetadataEntity에는 나중에 추천 알고리즘에 필요한 사용자 메타데이터 및 사용자 닉네임과 같은 User 인증/인가와 관련없는 퍼스널 데이터가 저장되는 Entity라 아래와 같은 DB 관계를 유지하는 것이 논리적으로 맞다고 생각했습니다.

> PostEntity - UserEntity(현재 supabase 사용 중) - UserMetadataEntity

## 🔊 도움이 필요한 부분
- 이거도 예외처리 부분을 리팩토링할때 함께 처리해야할 것 같습니다.
> adapter에 있는 예외처리의 관심사를 Handler로 이동시키는 작업