### PR TITLE
[KAN-111] [infra] fix: 브랜치 이름에 지라 ID 이후 슬래시를 통해 구분하도록 허용

### DIFF
--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -33,10 +33,13 @@ fi
 COMMIT_MESSAGE=$1
 
 BRANCH_NAME=$(git symbolic-ref --short HEAD)
-BRANCH_NAME="${BRANCH_NAME##*/}"
+echo "$BRANCH_NAME"
+# BRANCH_NAME="${BRANCH_NAME##*/}"
+# echo "$BRANCH_NAME"
 JIRA_ID=$(echo "$BRANCH_NAME" | egrep -o '(EI-[0-9]+|MC-[0-9]+|KAN-[0-9]+)')
 
-# merge commit 제외
+
+# # merge commit 제외
 MERGE=$(cat $COMMIT_MESSAGE|grep -i 'merge'|wc -l)
 
 if [ -n $JIRA_ID ] && [ $MERGE -eq 0 ] ; then


### PR DESCRIPTION
## ✅ 작업 내용
- 브랜치 명에 지라 ID 뒤에 슬래시를 허용하도록 허스키 파일을 수정