### PR TITLE
Mc 999 hotfix user

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -13,6 +13,8 @@ import { UserModule } from './user/user.module';
 import { addTransactionalDataSource } from 'typeorm-transactional';
 import { APP_GUARD } from '@nestjs/core';
 import { JwtAuthGuard } from './user/util/jwt-auth.guard';
+import { SupabaseModule } from './user/infrastructure/adapter/supabase/supabase.module';
+import { SupabaseConnection } from './user/infrastructure/adapter/supabase/supabase.connection';
 
 @Module({
   imports: [
@@ -36,13 +38,17 @@ import { JwtAuthGuard } from './user/util/jwt-auth.guard';
     CommunityModule,
     NumericalGuidanceModule,
     UserModule,
+    SupabaseModule,
   ],
   controllers: [AppController],
   providers: [
     AppService,
     {
       provide: APP_GUARD,
-      useClass: JwtAuthGuard,
+      useFactory: (supabaseConnection: SupabaseConnection) => {
+        return new JwtAuthGuard(supabaseConnection);
+      },
+      inject: [SupabaseConnection],
     },
   ],
 })

--- a/apps/api/src/community/test/unit-test/controller/post.controller.spec.ts
+++ b/apps/api/src/community/test/unit-test/controller/post.controller.spec.ts
@@ -3,6 +3,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { CommandBus, QueryBus } from '@nestjs/cqrs';
 import { CreatePostRequestDto } from '../../../api/dto/request/create-post.request.dto';
 import { mockUser1 } from '../../../../user/test/data/mock-user.user1';
+import { SupabaseConnection } from '../../../../user/infrastructure/adapter/supabase/supabase.connection';
 
 describe('PostController', () => {
   let postController: PostController;
@@ -19,6 +20,19 @@ describe('PostController', () => {
           provide: QueryBus,
           useValue: { execute: jest.fn() },
         },
+        {
+          provide: SupabaseConnection,
+          useValue: {
+            connection: {
+              auth: {
+                getUser: jest.fn().mockResolvedValue({
+                  data: { user: { id: 'mock-user-id', email: 'mockuser@example.com' } },
+                  error: null,
+                }),
+              },
+            },
+          },
+        },
       ],
     }).compile();
 
@@ -29,6 +43,7 @@ describe('PostController', () => {
     const createPostRequestDto: CreatePostRequestDto = {
       content: 'test content',
     };
+
     await expect(postController.createPost(createPostRequestDto, mockUser1)).resolves.not.toThrow();
   });
 });

--- a/apps/api/src/user/infrastructure/adapter/supabase/supabase.connection.ts
+++ b/apps/api/src/user/infrastructure/adapter/supabase/supabase.connection.ts
@@ -7,12 +7,20 @@ export class SupabaseConnection {
   private _connection: SupabaseClient;
 
   constructor() {
+    this.logger.log('SupabaseConnection 인스턴스 생성');
+
     try {
       const supabaseUrl = process.env.SUPABASE_URL;
       const supabaseKey = process.env.SUPABASE_KEY;
+
       if (!supabaseUrl || !supabaseKey) {
-        throw new BadRequestException('Supabase URL 또는 Key가 설정되지 않았습니다. 환경 변수를 확인하세요.');
+        const missingVars = [];
+        if (!supabaseUrl) missingVars.push('SUPABASE_URL');
+        if (!supabaseKey) missingVars.push('SUPABASE_KEY');
+        this.logger.error(`환경 변수가 누락되었습니다: ${missingVars.join(', ')}`);
+        throw new BadRequestException(`환경 변수가 누락되었습니다: ${missingVars.join(', ')}`);
       }
+
       this._connection = createClient(supabaseUrl, supabaseKey, {
         auth: { autoRefreshToken: true, persistSession: false },
       });
@@ -24,6 +32,10 @@ export class SupabaseConnection {
   }
 
   get connection(): SupabaseClient {
+    if (!this._connection) {
+      this.logger.error('Supabase 클라이언트가 초기화되지 않았습니다.');
+      throw new BadRequestException('Supabase 클라이언트가 초기화되지 않았습니다.');
+    }
     return this._connection;
   }
 }

--- a/apps/api/src/user/infrastructure/adapter/supabase/supabase.module.ts
+++ b/apps/api/src/user/infrastructure/adapter/supabase/supabase.module.ts
@@ -1,0 +1,9 @@
+import { Module, Global } from '@nestjs/common';
+import { SupabaseConnection } from './supabase.connection';
+
+@Global()
+@Module({
+  providers: [SupabaseConnection],
+  exports: [SupabaseConnection],
+})
+export class SupabaseModule {}

--- a/apps/api/src/user/util/jwt-auth.guard.ts
+++ b/apps/api/src/user/util/jwt-auth.guard.ts
@@ -1,4 +1,4 @@
-import { ExecutionContext, Inject, Injectable, UnauthorizedException } from '@nestjs/common';
+import { ExecutionContext, Inject, Injectable, Logger, UnauthorizedException } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { Request } from 'express';
 import { IS_PUBLIC_KEY } from './public.decorator';
@@ -8,12 +8,20 @@ import { SupabaseConnection } from '../infrastructure/adapter/supabase/supabase.
 @Injectable()
 export class JwtAuthGuard extends AuthGuard('jwt') {
   private reflector: Reflector = new Reflector();
+  private readonly logger = new Logger(JwtAuthGuard.name);
 
   constructor(
     @Inject(SupabaseConnection)
-    private supabaseConnection: SupabaseConnection,
+    private readonly supabaseConnection: SupabaseConnection,
   ) {
     super();
+
+    if (!this.supabaseConnection) {
+      this.logger.error('SupabaseConnection이 주입되지 않았습니다.');
+      throw new UnauthorizedException('SupabaseConnection이 주입되지 않았습니다.');
+    } else {
+      this.logger.log('SupabaseConnection이 성공적으로 주입되었습니다.');
+    }
   }
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
@@ -22,25 +30,53 @@ export class JwtAuthGuard extends AuthGuard('jwt') {
       context.getClass(),
     ]);
     if (isPublic) {
+      this.logger.log('Public endpoint입니다. 인증을 건너뜁니다.');
       return true;
     }
 
     const request = context.switchToHttp().getRequest();
     const token = this.extractTokenFromHeader(request);
+
     if (!token) {
-      throw new UnauthorizedException('[ERROR] 로그인하지 않은 사용자');
-    }
-    const { data, error } = await this.supabaseConnection.connection.auth.getUser(token);
-    if (error) {
-      throw new UnauthorizedException('[ERROR] 유효하지 않은 토큰', error.message);
+      this.logger.error('토큰이 요청 헤더에 없습니다.');
+      throw new UnauthorizedException('로그인하지 않은 사용자입니다.');
     }
 
-    request.user = data.user;
-    return true;
+    this.logger.log(`토큰 추출 성공: ${token}`);
+
+    try {
+      const { data, error } = await this.supabaseConnection.connection.auth.getUser(token);
+
+      if (error) {
+        this.logger.error(`Supabase 인증 오류: ${error.message}`);
+        throw new UnauthorizedException('토큰이 유효하지 않습니다.');
+      }
+
+      this.logger.log(`유저 인증 성공: ${JSON.stringify(data.user)}`);
+      request.user = data.user;
+      return true;
+    } catch (error) {
+      this.logger.error(`canActivate 중 오류 발생: ${error.message}`);
+      throw new UnauthorizedException('인증 과정에서 문제가 발생했습니다.');
+    }
   }
 
   private extractTokenFromHeader(request: Request): string | undefined {
-    const [type, token] = request.headers.authorization?.split(' ') ?? [];
-    return type === 'Bearer' ? token : undefined;
+    const authorizationHeader = request.headers.authorization;
+
+    if (!authorizationHeader) {
+      this.logger.error('Authorization 헤더가 없습니다.');
+      return undefined;
+    }
+
+    const [type, token] = authorizationHeader.split(' ');
+
+    if (type !== 'Bearer' || !token) {
+      this.logger.error(`Authorization 헤더 형식이 올바르지 않습니다. 헤더: ${authorizationHeader}`);
+      return undefined;
+    }
+
+    this.logger.debug(`Authorization 헤더에서 추출된 토큰: ${token}`);
+    return token;
   }
 }

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -7,40 +7,43 @@ import { fetchPosts } from './[id]/lib/data';
 import { CalendarIcon } from 'lucide-react';
 import BlogBreadcrumb from './[id]/components/blog-breadcrumb';
 import Callout from './ui/components/view/molecule/callout';
+import MockingUser from './ui/components/util/mocking-user';
 
 export default async function Page() {
   const posts = await fetchPosts();
 
   return (
     <>
-      <div className="min-h-screen bg-white">
-        <div className="fixed left-10 top-4">
-          <BlogBreadcrumb />
-        </div>
-        <div className="fixed bottom-2 left-1/2 z-10 -translate-x-1/2 rounded-lg ">
-          <Callout>
-            FINGOO 워크스페이스로 이동하려면{'   '}
-            <Link className="underline hover:text-gray-100" href="/blog">
-              여기
-            </Link>
-            를 클릭하세요.
-          </Callout>
-        </div>
-        <div className="mx-auto max-w-2xl ">
-          <div className="flex flex-col items-center justify-center pb-28 pt-20">
-            <h2 className="mb-2 text-4xl font-bold">FINGOO 블로그</h2>
+      <MockingUser>
+        <div className="min-h-screen bg-white">
+          <div className="fixed left-10 top-4">
+            <BlogBreadcrumb />
           </div>
-          {posts.map((post) => (
-            <Link key={post.id} href={`/${post.id}`}>
-              <BlogPostItem
-                title={post.title}
-                date={post.updatedAt.toISOString().slice(0, 10)}
-                preview={post.preview}
-              />
-            </Link>
-          ))}
+          <div className="fixed bottom-2 left-1/2 z-10 -translate-x-1/2 rounded-lg ">
+            <Callout>
+              FINGOO 워크스페이스로 이동하려면{'   '}
+              <Link className="underline hover:text-gray-100" href="/workspace">
+                여기
+              </Link>
+              를 클릭하세요.
+            </Callout>
+          </div>
+          <div className="mx-auto max-w-2xl ">
+            <div className="flex flex-col items-center justify-center pb-28 pt-20">
+              <h2 className="mb-2 text-4xl font-bold">FINGOO 블로그</h2>
+            </div>
+            {posts.map((post) => (
+              <Link key={post.id} href={`/${post.id}`}>
+                <BlogPostItem
+                  title={post.title}
+                  date={post.updatedAt.toISOString().slice(0, 10)}
+                  preview={post.preview}
+                />
+              </Link>
+            ))}
+          </div>
         </div>
-      </div>
+      </MockingUser>
     </>
   );
 }

--- a/apps/web/app/store/querys/api-path.ts
+++ b/apps/web/app/store/querys/api-path.ts
@@ -6,7 +6,7 @@ const API_URL =
       : 'http://localhost:8000/api';
 
 export const API_PATH = {
-  auth: `${API_URL}/auth`,
+  user: `${API_URL}/user`,
   indicatorList: `${API_URL}/numerical-guidance/indicator`,
   indicatorBoardMetadata: `${API_URL}/numerical-guidance/indicator-board-metadata`,
   liveIndicatorValue: `${API_URL}/numerical-guidance/indicators/live`, // refactor: be 수정되면 k-stock 사라져야함

--- a/apps/web/app/ui/components/util/mocking-user.tsx
+++ b/apps/web/app/ui/components/util/mocking-user.tsx
@@ -9,7 +9,7 @@ export default function MockingUser({ children }: React.PropsWithChildren) {
   useEffect(() => {
     async function enableMocking() {
       if (typeof window !== 'undefined') {
-        const response = await fetch(`${API_PATH.auth}/signIn`, {
+        const response = await fetch(`${API_PATH.user}/signIn`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
@@ -22,8 +22,8 @@ export default function MockingUser({ children }: React.PropsWithChildren) {
 
         console.log(response);
         const result = await response.json();
-        // console.log(result);
-        Cookies.set('accessToken', result.accessToken, {
+        console.log(result);
+        Cookies.set('accessToken', result.session.access_token, {
           secure: true,
           path: '/',
         });


### PR DESCRIPTION
## ✅ 작업 내용
- SupabaseModule 글로벌 모듈 설정
- API_PATH.auth -> API_PATH.user 로 변경
- MockingUser 컴포넌트에서 result.session.access_token을 쿠키에 저장하도록 수정
- 모킹용 유저 데이터를 supabase user_metadatas 테이블에 직접 추가

## 🤔 고민 했던 부분

### 1. 500 응답 문제
- /workspace?isMocking=false 페이지에서 API 요청 시 500 응답과 함께  Cannot read properties of undefined (reading 'connection') 오류, accessToken이 undefined로 설정되는 문제가 있었습니다. 

- PR과 커밋을 롤백하며 디버깅한 결과, https://github.com/Fingoo-org/Fingoo/pull/296 PR 이후 동일한 문제가 발생했습니다. 이에 따라 79370889cb44612eb772e87b4b222ddc8dd90472
 커밋 기준으로 롤백하여 이슈를 재현하였습니다. 

- 디버깅 결과, SupabaseConnection 객체 초기화는 성공했으나 이후 dependency injection 과정에서 제대로 연결되지 않는 문제가 있었습니다. 이를 해결하기 위해 SupabaseConnection을 글로벌 모듈로 설정하여 모든 곳에서 동일한 인스턴스를 참조하도록 수정하였습니다.

### 2. 401 응답 문제
- 전역으로 처리해주니 500이 아닌 401 응답이 나오게 되었는데요,
- MockingUser 컴포넌트가 루트 페이지에서 렌더링되지 않아 토큰 생성을 못 하고 있어 루트 페이지에 MockingUser 컴포넌트를 렌더링하도록 수정하였습니다. 

### 3. 404 응답 (API_PATH)
- MockingUser 컴포넌트가 렌더링되는데도 token을 제대로 받아오지 못해, curl -x POST http://localhost:8000/api/auth/signIn 명령어로 확인해보니 404 응답이 반환되었습니다.
- 이에 따라 백엔드쪽 코드를 확인해보니 API path가 /auth가 아닌 /user로 되어 있어 프론트쪽 API_PATH를 변경해주었고, 응답 값에 맞게 토큰을 쿠키에 저장하도록 수정하였습니다. 

### 4. 404 응답 (user_metadatas)
- 마지막으로 /workspace 관련 api 요청 시 user_metadatas 테이블에서 유저를 조회하는데, supabase user_metadatas 테이블이 비어있어 404가 뜨는 문제가 있었습니다.
- 이에 따라 모킹에 사용되는 데이터만 user_metadatas 테이블에 임시로 직접 추가해주었습니다.


## 🔊 도움이 필요한 부분
- users와 user_metadatas의 동기화를 어떤 방식으로 진행할 예정인지 궁금합니다.
- 백엔드 코드를 약간 수정했는데 미흡한 점이 있다면 피드백 부탁드립니다.
- 디버깅 과정에서 로깅 코드를 추가했는데 불필요하거나 거슬리는 부분이 있다면 말씀해주세요!